### PR TITLE
Add Horizontal Margin and Padding

### DIFF
--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -107,6 +107,33 @@ abstract class Element
     }
 
     /**
+     * Adds 2 horizontal margin to the element.
+     */
+    final public function mx2(): static
+    {
+        return $this->mx(2);
+    }
+
+    /**
+     * Adds 1 horizontal margin to the element.
+     */
+    final public function mx1(): static
+    {
+        return $this->mx(1);
+    }
+
+    /**
+     * Adds the given horizontal margin to the element.
+     */
+    final public function mx(int $margin): static
+    {
+        return $this->with(['styles' => [
+            'ml' => $margin,
+            'mr' => $margin,
+        ]]);
+    }
+
+    /**
      * Adds 2 padding left to the element.
      */
     final public function pl2(): static
@@ -156,6 +183,30 @@ abstract class Element
         $value = sprintf('%s%s', $this->value, str_repeat(' ', $padding));
 
         return new static($this->output, $value, $this->properties);
+    }
+
+    /**
+     * Adds 2 horizontal padding to the element.
+     */
+    final public function px2(): static
+    {
+        return $this->px(2);
+    }
+
+    /**
+     * Adds 1 horizontal padding to the element.
+     */
+    final public function px1(): static
+    {
+        return $this->px(1);
+    }
+
+    /**
+     * Adds the given horizontal padding to the element.
+     */
+    final public function px(int $padding): static
+    {
+        return $this->pl($padding)->pr($padding);
     }
 
     /**

--- a/tests/Line.php
+++ b/tests/Line.php
@@ -34,6 +34,14 @@ it('adds padding right', function () {
     expect($line->toString())->toBe('<bg=default;options=>string  </>');
 });
 
+it('adds horizontal padding', function () {
+    $line = line('string');
+
+    $line = $line->px2();
+
+    expect($line->toString())->toBe('<bg=default;options=>  string  </>');
+});
+
 it('adds background color', function () {
     $line = line('string');
 
@@ -92,6 +100,17 @@ it('adds margin right', function () {
 
     expect($line->toString())->toBe('<bg=default;options=>string</>  ');
     expect($lineWithBackground->toString())->toBe('<bg=white;options=>string</>  ');
+});
+
+it('adds horizontal margin', function () {
+    $line = line('string');
+    $lineWithBackground = line('string')->bg('white');
+
+    $line = $line->mx2();
+    $lineWithBackground = $lineWithBackground->mx2();
+
+    expect($line->toString())->toBe('  <bg=default;options=>string</>  ');
+    expect($lineWithBackground->toString())->toBe('  <bg=white;options=>string</>  ');
 });
 
 it('sets the text uppercase', function () {


### PR DESCRIPTION
This PR adds the capability to add a `px` and `mx` method to the line element, inspired by https://tailwindcss.com/docs/padding#add-horizontal-padding

This will replace the need to have `$line->pl($padding)->pr($padding)` and use only the `$this->px($padding)` the same logic is added also the `$line->ml()` and `$line->mr()`.
