### PR TITLE
Add href method

### DIFF
--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -297,6 +297,15 @@ abstract class Element
     }
 
     /**
+     * Adds a hyperlink to the element.
+     */
+    final public function href(string $href = ''): static
+    {
+        // @phpstan-ignore-next-line
+        return $this->with(['href' => $href === '' ? $this->value : $href]);
+    }
+
+    /**
      * Renders the string representation of the element on the output.
      */
     final public function render(): void
@@ -327,8 +336,10 @@ abstract class Element
         }
 
         return sprintf(
-            '%s<%s;options=%s>%s</>%s',
+            '%s<%s%s;options=%s>%s</>%s',
             str_repeat(' ', (int) ($this->properties['styles']['ml'] ?? 0)),
+            // @phpstan-ignore-next-line
+            array_key_exists('href', $this->properties) ? sprintf('href=%s;', $this->properties['href']) : '',
             implode(';', $colors),
             implode(',', $options),
             $this->value,

--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -299,10 +299,10 @@ abstract class Element
     /**
      * Adds a hyperlink to the element.
      */
-    final public function href(string $href = ''): static
+    final public function href(string $href): static
     {
         // @phpstan-ignore-next-line
-        return $this->with(['href' => $href === '' ? $this->value : $href]);
+        return $this->with(['href' => $href]);
     }
 
     /**
@@ -329,6 +329,9 @@ abstract class Element
             }
         }
 
+        /** @var string $href */
+        $href = $this->properties['href'] ?? '';
+
         $options = [];
 
         foreach ($this->properties['options'] as $option) {
@@ -338,8 +341,7 @@ abstract class Element
         return sprintf(
             '%s<%s%s;options=%s>%s</>%s',
             str_repeat(' ', (int) ($this->properties['styles']['ml'] ?? 0)),
-            // @phpstan-ignore-next-line
-            array_key_exists('href', $this->properties) ? sprintf('href=%s;', $this->properties['href']) : '',
+            $href === '' ? '' : sprintf('href=%s;', $href),
             implode(';', $colors),
             implode(',', $options),
             $this->value,

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -17,6 +17,16 @@ if (! function_exists('line')) {
     }
 }
 
+if (! function_exists('a')) {
+    /**
+     * Creates a line element instance with the given link.
+     */
+    function a(string $href = ''): Components\Line
+    {
+        return Termwind::line($href)->href($href);
+    }
+}
+
 if (! function_exists('renderUsing')) {
     /**
      * Sets the renderer implementation.

--- a/tests/Line.php
+++ b/tests/Line.php
@@ -161,3 +161,14 @@ it('sets the text in snakecase', function () {
 
     expect($line->toString())->toBe('<bg=default;options=>snake_case snake_case snake_case snake_case</>');
 });
+
+it('adds hyperlink', function () {
+    $line = line('Termwind');
+    $hyperlink = line('https://github.com/nunomaduro/termwind');
+
+    $line = $line->href('https://github.com/nunomaduro/termwind');
+    $hyperlink = $hyperlink->href();
+
+    expect($line->toString())->toBe('<href=https://github.com/nunomaduro/termwind;bg=default;options=>Termwind</>');
+    expect($hyperlink->toString())->toBe('<href=https://github.com/nunomaduro/termwind;bg=default;options=>https://github.com/nunomaduro/termwind</>');
+});

--- a/tests/Line.php
+++ b/tests/Line.php
@@ -1,7 +1,7 @@
 <?php
 
 use Termwind\Enums\Color;
-use function Termwind\{line};
+use function Termwind\{line,a};
 
 it('adds font bold', function () {
     $line = line('string');
@@ -164,11 +164,10 @@ it('sets the text in snakecase', function () {
 
 it('adds hyperlink', function () {
     $line = line('Termwind');
-    $hyperlink = line('https://github.com/nunomaduro/termwind');
+    $anchor = a('https://github.com/nunomaduro/termwind');
 
     $line = $line->href('https://github.com/nunomaduro/termwind');
-    $hyperlink = $hyperlink->href();
 
     expect($line->toString())->toBe('<href=https://github.com/nunomaduro/termwind;bg=default;options=>Termwind</>');
-    expect($hyperlink->toString())->toBe('<href=https://github.com/nunomaduro/termwind;bg=default;options=>https://github.com/nunomaduro/termwind</>');
+    expect($anchor->toString())->toBe('<href=https://github.com/nunomaduro/termwind;bg=default;options=>https://github.com/nunomaduro/termwind</>');
 });


### PR DESCRIPTION
I know it's not a part of the Tailwind CSS API, but I've added an `href` method to render clickable [hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda):

```php
// Adds a hyperlink to the text
line('Termwind')->href('https://github.com/nunomaduro/termwind');

// Renders the text as hyperlink
line('https://github.com/nunomaduro/termwind')->href();
```