### PR TITLE
[Feature] ability to define presets for multiple usage

### DIFF
--- a/src/Exceptions/UndefinedTermwindPresetException.php
+++ b/src/Exceptions/UndefinedTermwindPresetException.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Termwind\Exceptions;
+
+use Exception;
+
+final class UndefinedTermwindPresetException extends Exception
+{
+
+    /**
+     * An undefined termwind preset exception
+     *
+     * @param string $presetName
+     */
+    public function __construct(string $presetName)
+    {
+        $message = sprintf("%s is not a defined Termwind Preset", $presetName);
+
+        parent::__construct($message);
+    }
+}

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Termwind;
 
+use Closure;
 use Symfony\Component\Console\Output\OutputInterface;
 use Termwind\Components\Element;
 
@@ -36,5 +37,19 @@ if (! function_exists('render')) {
     function render(array $elements): void
     {
         Termwind::render($elements);
+    }
+}
+
+if (!function_exists('register_preset')) {
+    function register_preset(string $name,  Closure $style): void
+    {
+        Preset::register($name, $style);
+    }
+}
+
+if (!function_exists('render_preset')) {
+    function render_preset(string $message, string $preset): mixed
+    {
+        return Preset::design($message, $preset);
     }
 }

--- a/src/Preset.php
+++ b/src/Preset.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Termwind;
+
+use Closure;
+use Termwind\Exceptions\UndefinedTermwindPresetException;
+
+final class Preset
+{
+    /**
+     * @var array<string, callable> $presets
+     */
+    public static array $presets = [];
+
+    /**
+     * Register a new preset with some styles
+     *
+     * @param string $name
+     * @param Closure $styles
+     */
+    public static function register(string $name, Closure $styles): void
+    {
+        self::$presets[$name] = $styles;
+    }
+
+    /**
+     * Design a message with a predefined preset
+     *
+     * @param string $message
+     * @param string $presetName
+     * @return mixed
+     * @throws UndefinedTermwindPresetException
+     */
+    public static function design(string $message, string $presetName): mixed
+    {
+        if (!array_key_exists($presetName, self::$presets)) {
+            throw new UndefinedTermwindPresetException($presetName);
+        }
+
+        return call_user_func(self::$presets[$presetName], $message);
+    }
+
+
+}

--- a/tests/Preset.php
+++ b/tests/Preset.php
@@ -1,0 +1,56 @@
+<?php
+
+use Termwind\Exceptions\UndefinedTermwindPresetException;
+use Termwind\Preset;
+use function Termwind\line;
+use function Termwind\register_preset;
+use function Termwind\render_preset;
+
+/**
+ * after each test clear the predefined presets
+ */
+afterEach(fn() => Preset::$presets = []);
+
+
+it('register a preset', function () {
+    Preset::register('primary-design', function ($message) {
+        return line($message)->bg('blue');
+    });
+
+    expect(count(Preset::$presets))->toBe(1);
+});
+
+it('register a preset by function', function () {
+    register_preset('primary-design', function ($message) {
+        return line($message)->bg('blue');
+    });
+
+    expect(count(Preset::$presets))->toBe(1);
+});
+
+
+it('use a preset', function () {
+    Preset::register('primary-design', function ($message) {
+        return line($message)->bg('blue');
+    });
+
+    $output = Preset::design('arsan', 'primary-design');
+
+    expect($output->toString())->toBe('<bg=blue;options=>arsan</>');
+});
+
+it('use a preset by function', function () {
+    register_preset('primary-design', function ($message) {
+        return line($message)->bg('blue');
+    });
+
+    $output = render_preset('arsan', 'primary-design');
+
+    expect($output->toString())->toBe('<bg=blue;options=>arsan</>');
+});
+
+it('cant use a non-existent preset', function(){
+    $output = Preset::design("some message",'some-preset');
+})->throws(UndefinedTermwindPresetException::class);
+
+


### PR DESCRIPTION
Hello @nunomaduro,

I am so excited to propose this pull request, as it will give the ability for developers to predefine a preset and use it as many times as needed.

So instead of doing this
```php
line("my name is arsan")->bg('red')->fontBold()->render();
line("I am 26 years old")->bg('red')->fontBold()->render();
line("I love Termwind")->bg('red')->fontBold()->render();
```

you can predefine the styles once like so
```php
use Termwind\Preset;

Preset::register("preset-name", function($message){
    // dont call render if you want to define only base styles
    // this will give more control
    return line($message)->bg('red')->fontBold();
});

Preset::design("my name is Arsan", 'preset-name')->render();
Preset::design("I am 26 years old", 'preset-name')->render();
Preset::design("I love Termwind", 'preset-name')->render();
```

or

```php
use Termwind\Preset;

Preset::register("preset-name", function($message){
    // always render on calling Preset::design
    line($message)->bg('red')->fontBold()->render();
});

Preset::design("my name is Arsan", 'preset-name');
Preset::design("I am 26 years old", 'preset-name');
Preset::design("I love Termwind", 'preset-name');
```

This will ensure developers won't write the same styles more than once, which clearly implements the Tailwind CSS API of defining components and `@apply`.

Thanks for your efforts.

