### PR TITLE
Remove padding and margin proxy methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ composer require nunomaduro/termwind --dev
 use function Termwind\{span, render};
 
 // Render one span...
-span($message)->uppercase()->pl2()->pr2()->fontBold()->textColor('white')->bg('blue')->render();
+span($message)->uppercase()->pl(2)->pr(2)->fontBold()->textColor('white')->bg('blue')->render();
 span($message, 'uppercase pl-2 pr-2 font-bold text-color-white bg-blue')->render();
 
 

--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -76,22 +76,6 @@ abstract class Element
     }
 
     /**
-     * Adds 2 margin left to the element.
-     */
-    final public function ml2(): static
-    {
-        return $this->ml(2);
-    }
-
-    /**
-     * Adds 1 margin left to the element.
-     */
-    final public function ml1(): static
-    {
-        return $this->ml(1);
-    }
-
-    /**
      * Adds the given margin left to the element.
      */
     final public function ml(int $margin): static
@@ -102,22 +86,6 @@ abstract class Element
     }
 
     /**
-     * Adds 2 margin right to the element.
-     */
-    final public function mr2(): static
-    {
-        return $this->mr(2);
-    }
-
-    /**
-     * Adds 1 margin right to the element.
-     */
-    final public function mr1(): static
-    {
-        return $this->mr(1);
-    }
-
-    /**
      * Adds the given margin right to the element.
      */
     final public function mr(int $margin): static
@@ -125,22 +93,6 @@ abstract class Element
         return $this->with(['styles' => [
             'mr' => $margin,
         ]]);
-    }
-
-    /**
-     * Adds 2 horizontal margin to the element.
-     */
-    final public function mx2(): static
-    {
-        return $this->mx(2);
-    }
-
-    /**
-     * Adds 1 horizontal margin to the element.
-     */
-    final public function mx1(): static
-    {
-        return $this->mx(1);
     }
 
     /**
@@ -155,22 +107,6 @@ abstract class Element
     }
 
     /**
-     * Adds 2 padding left to the element.
-     */
-    final public function pl2(): static
-    {
-        return $this->pl(2);
-    }
-
-    /**
-     * Adds 1 padding left to the element.
-     */
-    final public function pl1(): static
-    {
-        return $this->pl(1);
-    }
-
-    /**
      * Adds the given padding left to the element.
      */
     final public function pl(int $padding): static
@@ -181,22 +117,6 @@ abstract class Element
     }
 
     /**
-     * Adds 2 padding right to the element.
-     */
-    final public function pr2(): static
-    {
-        return $this->pr(2);
-    }
-
-    /**
-     * Adds 1 padding right to the element.
-     */
-    final public function pr1(): static
-    {
-        return $this->pr(1);
-    }
-
-    /**
      * Adds the given padding right to the element.
      */
     final public function pr(int $padding): static
@@ -204,22 +124,6 @@ abstract class Element
         $value = sprintf('%s%s', $this->value, str_repeat(' ', $padding));
 
         return new static($this->output, $value, $this->properties);
-    }
-
-    /**
-     * Adds 2 horizontal padding to the element.
-     */
-    final public function px2(): static
-    {
-        return $this->px(2);
-    }
-
-    /**
-     * Adds 1 horizontal padding to the element.
-     */
-    final public function px1(): static
-    {
-        return $this->px(1);
     }
 
     /**

--- a/tests/Element.php
+++ b/tests/Element.php
@@ -17,7 +17,7 @@ it('renders', function () {
 it('can receive styles as strings', function () {
     renderUsing($output = new BufferedOutput());
 
-    $a = span('string', 'text-color-red bg-white pr-2')->pl2();
+    $a = span('string', 'text-color-red bg-white pr-2')->pl(2);
     $b = span('string', 'ml-3 font-bold');
 
     expect($a->toString())->toBe('<bg=white;fg=red;options=>  string  </>');

--- a/tests/Span.php
+++ b/tests/Span.php
@@ -22,7 +22,7 @@ it('adds underspan', function () {
 it('adds padding left', function () {
     $span = span('string');
 
-    $span = $span->pl2();
+    $span = $span->pl(2);
 
     expect($span->toString())->toBe('<bg=default;options=>  string</>');
 });
@@ -30,7 +30,7 @@ it('adds padding left', function () {
 it('adds padding right', function () {
     $span = span('string');
 
-    $span = $span->pr2();
+    $span = $span->pr(2);
 
     expect($span->toString())->toBe('<bg=default;options=>string  </>');
 });
@@ -38,7 +38,7 @@ it('adds padding right', function () {
 it('adds horizontal padding', function () {
     $span = span('string');
 
-    $span = $span->px2();
+    $span = $span->px(2);
 
     expect($span->toString())->toBe('<bg=default;options=>  string  </>');
 });
@@ -101,8 +101,8 @@ it('adds margin left', function () {
     $span = span('string');
     $spanWithBackground = span('string')->bg('white');
 
-    $span = $span->ml2();
-    $spanWithBackground = $spanWithBackground->ml2();
+    $span = $span->ml(2);
+    $spanWithBackground = $spanWithBackground->ml(2);
 
     expect($span->toString())->toBe('  <bg=default;options=>string</>');
     expect($spanWithBackground->toString())->toBe('  <bg=white;options=>string</>');
@@ -112,8 +112,8 @@ it('adds margin right', function () {
     $span = span('string');
     $spanWithBackground = span('string')->bg('white');
 
-    $span = $span->mr2();
-    $spanWithBackground = $spanWithBackground->mr2();
+    $span = $span->mr(2);
+    $spanWithBackground = $spanWithBackground->mr(2);
 
     expect($span->toString())->toBe('<bg=default;options=>string</>  ');
     expect($spanWithBackground->toString())->toBe('<bg=white;options=>string</>  ');
@@ -123,8 +123,8 @@ it('adds horizontal margin', function () {
     $span = span('string');
     $spanWithBackground = span('string')->bg('white');
 
-    $span = $span->mx2();
-    $spanWithBackground = $spanWithBackground->mx2();
+    $span = $span->mx(2);
+    $spanWithBackground = $spanWithBackground->mx(2);
 
     expect($span->toString())->toBe('  <bg=default;options=>string</>  ');
     expect($spanWithBackground->toString())->toBe('  <bg=white;options=>string</>  ');

--- a/tests/Termwind.php
+++ b/tests/Termwind.php
@@ -14,7 +14,7 @@ it('renders', function () {
 
     render([
         span(),
-        span('string')->pr1(),
+        span('string')->pr(1),
     ]);
 
     expect($output->fetch())->toBe("\nstring \n");


### PR DESCRIPTION
To have it working the same way `text-color` and `bg-color` and with the addition of accepting strings make sense to remove `ml1`, `ml2`, etc. and have the `margin` and `padding` working the same way.

What do you think @nunomaduro?