### PR TITLE
Rename `titlecase` to `capitalize` in order to match the tailwindcss method name.

### DIFF
--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -295,9 +295,9 @@ abstract class Element
     }
 
     /**
-     * Makes the element's content in titlecase.
+     * Makes the element's content capitalize.
      */
-    final public function titlecase(): static
+    final public function capitalize(): static
     {
         $value = mb_convert_case($this->value, MB_CASE_TITLE, 'UTF-8');
 

--- a/tests/Span.php
+++ b/tests/Span.php
@@ -146,12 +146,12 @@ it('sets the text lowercase', function () {
     expect($span->toString())->toBe('<bg=default;options=>string</>');
 });
 
-it('sets the text in titlecase', function () {
-    $span = span('STRING titlecase');
+it('sets the text capitalize', function () {
+    $span = span('STRING capitalized');
 
-    $span = $span->titlecase();
+    $span = $span->capitalize();
 
-    expect($span->toString())->toBe('<bg=default;options=>String Titlecase</>');
+    expect($span->toString())->toBe('<bg=default;options=>String Capitalized</>');
 });
 
 it('sets the text in snakecase', function () {


### PR DESCRIPTION
After checking the TailwindCSS documentation, https://tailwindcss.com/docs/text-transform#capitalize

Makes sense to rename titlecase to capitalize to match the same method name.