### PR TITLE
Implement anchor element

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ render(
 );
 ```
 
+#### `a()`
+
+The `a()` function may be used to render an inline anchor container used to mark up a clickable hyperlink.
+
+```php
+use function Termwind\{render, a};
+
+a('https://github.com/nunomaduro/termwind', 'p-2 text-color-white bg-blue')->render();
+
+render(
+    a('https://github.com/nunomaduro/termwind', 'p-2 text-color-white bg-blue'),
+    a('Termwind', 'p-2 text-color-white bg-blue')->href('https://github.com/nunomaduro/termwind'),
+);
+```
+
 #### `style()`
 
 The `style()` function may be used to add own custom syles.

--- a/src/Components/Anchor.php
+++ b/src/Components/Anchor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Termwind\Components;
+
+final class Anchor extends Element
+{
+    /**
+     * Sets the href property to the element.
+     */
+    public function href(string $href): self
+    {
+        // @phpstan-ignore-next-line
+        return new self($this->output, $this->value, array_merge($this->properties, ['href' => $href]));
+    }
+}

--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -243,6 +243,9 @@ abstract class Element
             }
         }
 
+        /** @var string $href */
+        $href = $this->properties['href'] ?? '';
+
         $options = [];
 
         foreach ($this->properties['options'] as $option) {
@@ -250,8 +253,9 @@ abstract class Element
         }
 
         return sprintf(
-            '%s<%s;options=%s>%s</>%s',
+            '%s<%s%s;options=%s>%s</>%s',
             str_repeat(' ', (int) ($this->properties['styles']['ml'] ?? 0)),
+            $href === '' ? '' : sprintf('href=%s;', $href),
             implode(';', $colors),
             implode(',', $options),
             $this->value,

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -42,6 +42,16 @@ if (! function_exists('span')) {
     }
 }
 
+if (! function_exists('a')) {
+    /**
+     * Creates a line element instance with the given link.
+     */
+    function a(string $value = ''): Components\Anchor
+    {
+        return Termwind::anchor($value);
+    }
+}
+
 if (! function_exists('style')) {
     /**
      * Creates a new style.

--- a/src/Termwind.php
+++ b/src/Termwind.php
@@ -37,6 +37,16 @@ final class Termwind
     }
 
     /**
+     * Creates an anchor element instance with the given style.
+     */
+    public static function anchor(string $value = '', string $styles = ''): Components\Anchor
+    {
+        return Components\Anchor::fromStyles(
+            self::getRenderer(), $value, $styles,
+        )->href($value);
+    }
+
+    /**
      * Renders the given elements.
      *
      * @param  array<int, Element|array<int, Element>>  $elements

--- a/tests/Anchor.php
+++ b/tests/Anchor.php
@@ -1,0 +1,13 @@
+<?php
+
+use function Termwind\{a};
+
+it('renders an anchor', function () {
+    $anchor = a('https://github.com/nunomaduro/termwind');
+    $anchorWithValue = a('Termwind');
+
+    $anchorWithValue = $anchorWithValue->href('https://github.com/nunomaduro/termwind');
+
+    expect($anchorWithValue->toString())->toBe('<href=https://github.com/nunomaduro/termwind;bg=default;options=>Termwind</>');
+    expect($anchor->toString())->toBe('<href=https://github.com/nunomaduro/termwind;bg=default;options=>https://github.com/nunomaduro/termwind</>');
+});


### PR DESCRIPTION
This PR adds an `Anchor` component and an `a()` function to render clickable hyperlinks.

```php
// Adds a hyperlink
a('https://github.com/nunomaduro/termwind');

// Adds a hyperlink with text value
a('Termwind')->href('https://github.com/nunomaduro/termwind');
```