### PR TITLE
Add text decoration line-through method

### DIFF
--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -220,6 +220,16 @@ abstract class Element
     }
 
     /**
+     * Makes the element's content capitalize.
+     */
+    final public function lineThrough(): static
+    {
+        $value = sprintf("\e[9m%s\e[0m", $this->value);
+
+        return new static($this->output, $value, $this->properties);
+    }
+
+    /**
      * Renders the string representation of the element on the output.
      */
     final public function render(): void

--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -220,7 +220,7 @@ abstract class Element
     }
 
     /**
-     * Makes the element's content capitalize.
+     * Makes the element's content with a line through.
      */
     final public function lineThrough(): static
     {

--- a/tests/Span.php
+++ b/tests/Span.php
@@ -161,3 +161,11 @@ it('sets the text in snakecase', function () {
 
     expect($span->toString())->toBe('<bg=default;options=>snake_case snake_case snake_case snake_case</>');
 });
+
+it('sets the text with line-through', function () {
+    $span = span('line');
+
+    $span = $span->lineThrough();
+
+    expect($span->toString())->toBe("<bg=default;options=>\e[9mline\e[0m</>");
+});


### PR DESCRIPTION
This PR adds a method available on TailwindCSS `line-through`: https://tailwindcss.com/docs/text-decoration#line-through.

@nunomaduro checked for an option on the symfony/console package but did not found any.

Let me know if there is a better option.

