### PR TITLE
chore: fix incorrect span find & replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 ------
-**Termwind** allows you to build unique and beautiful PHP command-span applications, using the **[Tailwind CSS](https://tailwindcss.com/)** API. In short, it's like Tailwind CSS, but for the PHP command-span applications.
+**Termwind** allows you to build unique and beautiful PHP command-span applications, using the **[Tailwind CSS](https://tailwindcss.com/)** API. In short, it's like Tailwind CSS, but for the PHP command-line applications.
 
 ## Installation & Usage
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 ------
-**Termwind** allows you to build unique and beautiful PHP command-span applications, using the **[Tailwind CSS](https://tailwindcss.com/)** API. In short, it's like Tailwind CSS, but for the PHP command-line applications.
+**Termwind** allows you to build unique and beautiful PHP command-line applications, using the **[Tailwind CSS](https://tailwindcss.com/)** API. In short, it's like Tailwind CSS, but for the PHP command-line applications.
 
 ## Installation & Usage
 


### PR DESCRIPTION
Correct me if I'm wrong, but I think this was an unintentional change when you converted `line()` to `span()`.