### PR TITLE
feat: add line and link aliases

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -42,7 +42,27 @@ if (! function_exists('span')) {
     }
 }
 
+if (! function_exists('line')) {
+    /**
+     * Creates a span element instance with the given style.
+     */
+    function line(string $value = '', string $styles = ''): Components\Span
+    {
+        return Termwind::span($value, $styles);
+    }
+}
+
 if (! function_exists('a')) {
+    /**
+     * Creates a line element instance with the given link.
+     */
+    function a(string $value = '', string $styles = ''): Components\Anchor
+    {
+        return Termwind::anchor($value, $styles);
+    }
+}
+
+if (! function_exists('link')) {
     /**
      * Creates a line element instance with the given link.
      */


### PR DESCRIPTION
This makes sure that the CLI purists (including myself) can use the old `line` method. The recently added `a()` aliases to `link()`. I know this is a personal opinion, but I think the package can support both uses.

I was a bit unsure if I should test this. The other functions didn't seem to have tests either. I haven't jumped on the PEST train either (yet) but the docs are really clear, so it should be doable to make some tests for it if needed.

If you disagree with this feature, no worries. As a user you can always alias it yourself, if you want.