### PR TITLE
Add text decoration hidden method

### DIFF
--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -278,6 +278,16 @@ abstract class Element
     }
 
     /**
+     * Makes the element's content invisible.
+     */
+    final public function hidden(): static
+    {
+        $content = sprintf("\e[8m%s\e[0m", $this->content);
+
+        return new static($this->output, $content, $this->properties);
+    }
+
+    /**
      * Renders the string representation of the element on the output.
      */
     final public function render(): void

--- a/tests/a.php
+++ b/tests/a.php
@@ -207,3 +207,11 @@ it('can receive text-color class names as string', function () {
 
     expect($a->toString())->toBe('<href=with color;bg=default;fg=#86efac;options=>with color</>');
 });
+
+it('hides the text', function () {
+    $a = a('string');
+
+    $a = $a->hidden();
+
+    expect($a->toString())->toBe("<href=string;bg=default;options=>\e[8mstring\e[0m</>");
+});

--- a/tests/div.php
+++ b/tests/div.php
@@ -224,3 +224,11 @@ it('can receive text-color class names as string', function () {
 
     expect($div->toString())->toBe('<bg=default;fg=#86efac;options=>with color</>');
 });
+
+it('hides the text', function () {
+    $div = div('string');
+
+    $div = $div->hidden();
+
+    expect($div->toString())->toBe("<bg=default;options=>\e[8mstring\e[0m</>");
+});

--- a/tests/span.php
+++ b/tests/span.php
@@ -226,3 +226,11 @@ it('throws if text-color class names as string received is not found', function 
         fn () => span('with color', 'text-color-invalidColor-300')
     )->toThrow(ColorNotFound::class);
 });
+
+it('hides the text', function () {
+    $span = span('string');
+
+    $span = $span->hidden();
+
+    expect($span->toString())->toBe("<bg=default;options=>\e[8mstring\e[0m</>");
+});


### PR DESCRIPTION
This PR adds `hidden` method for text decoration. It will make the text invisible when applied.

```php
span('i am invisible with blue background color', 'hidden bg-blue')->render();
```

I do not know if this will be useful or not, but it is part of [ANSI Escape Codes](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#colors--graphics-mode). Also there are `reverse`, `dim` and `blink` which is not yet added to this package. 

Feel free to drop or accept this, cheers :beers: 

---

Apart from this PR, i also have some idea about this package:

1. What if there is helper function called `console` which return the current renderer of termwind. It will be useful when we need the symfony console output directly.

```php
// print an error
console()->writeln('<error>An error occured</error>');
```

2. What if there is conditional rendering, using something like:

```php
span('i am on linux machine')->renderWhen(PHP_OS_FAMILY  == 'Linux');
span('i am on macos machine')->renderWhen(PHP_OS_FAMILY  == 'Darwin');
span('i am on windows machine')->renderWhen(PHP_OS_FAMILY  == 'Windows');
```

3. Does this package going to achieve same goal as `rich` python package?
  link: https://github.com/willmcgugan/rich

What do you think @nunomaduro ?