### PR TITLE
Add Support to color class names like TailwindCSS

### DIFF
--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -83,6 +83,6 @@ final class StyleToMethod
             return $this->__invoke(...$arguments);
         }
 
-        return $this->element->$methodName(...$arguments);
+        return $this->element->$methodName(...array_reverse($arguments));
     }
 }

--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -6,6 +6,8 @@ namespace Termwind\Components;
 
 use Symfony\Component\Console\Output\OutputInterface;
 use Termwind\Actions\StyleToMethod;
+use Termwind\Enums\Color;
+use Termwind\Exceptions\ColorNotFound;
 
 /**
  * @internal
@@ -43,8 +45,12 @@ abstract class Element
     /**
      * Adds a background color to the element.
      */
-    final public function bg(string $color): static
+    final public function bg(string $color, int $variant = 0): static
     {
+        if ($variant > 0) {
+            $color = $this->getColorVariant($color, $variant);
+        }
+
         return $this->with(['colors' => ['bg' => $color]]);
     }
 
@@ -173,8 +179,12 @@ abstract class Element
     /**
      * Adds a text color to the element.
      */
-    final public function textColor(string $color): static
+    final public function textColor(string $color, int $variant = 0): static
     {
+        if ($variant > 0) {
+            $color = $this->getColorVariant($color, $variant);
+        }
+
         return $this->with(['colors' => [
             'fg' => $color,
         ]]);
@@ -334,5 +344,19 @@ abstract class Element
             $this->content,
             $properties,
         );
+    }
+
+    /**
+     * Get the constant variant color from Color class.
+     */
+    private function getColorVariant(string $color, int $variant): string
+    {
+        $colorConstant = mb_strtoupper($color.'_'.$variant, 'UTF-8');
+
+        if (! defined(Color::class."::$colorConstant")) {
+            throw new ColorNotFound($colorConstant);
+        }
+
+        return constant(Color::class."::$colorConstant");
     }
 }

--- a/src/Exceptions/ColorNotFound.php
+++ b/src/Exceptions/ColorNotFound.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Termwind\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * @internal
+ */
+final class ColorNotFound extends InvalidArgumentException
+{
+}

--- a/tests/a.php
+++ b/tests/a.php
@@ -195,3 +195,15 @@ it('sets the text with line-through', function () {
 
     expect($a->toString())->toBe("<href=string;bg=default;options=>\e[9mstring\e[0m</>");
 });
+
+it('can receive bg-color class names as string', function () {
+    $a = a('with color', 'bg-green-300');
+
+    expect($a->toString())->toBe('<href=with color;bg=#86efac;options=>with color</>');
+});
+
+it('can receive text-color class names as string', function () {
+    $a = a('with color', 'text-color-green-300');
+
+    expect($a->toString())->toBe('<href=with color;bg=default;fg=#86efac;options=>with color</>');
+});

--- a/tests/div.php
+++ b/tests/div.php
@@ -212,3 +212,15 @@ it('sets the text with line-through', function () {
 
     expect($div->toString())->toBe("<bg=default;options=>\e[9mstring\e[0m</>");
 });
+
+it('can receive bg-color class names as string', function () {
+    $div = div('with color', 'bg-green-300');
+
+    expect($div->toString())->toBe('<bg=#86efac;options=>with color</>');
+});
+
+it('can receive text-color class names as string', function () {
+    $div = div('with color', 'text-color-green-300');
+
+    expect($div->toString())->toBe('<bg=default;fg=#86efac;options=>with color</>');
+});

--- a/tests/span.php
+++ b/tests/span.php
@@ -1,6 +1,7 @@
 <?php
 
 use Termwind\Enums\Color;
+use Termwind\Exceptions\ColorNotFound;
 use function Termwind\{span};
 
 it('adds font bold', function () {
@@ -200,4 +201,28 @@ it('sets the text with line-through', function () {
     $span = $span->lineThrough();
 
     expect($span->toString())->toBe("<bg=default;options=>\e[9mstring\e[0m</>");
+});
+
+it('can receive bg-color class names as string', function () {
+    $span = span('with color', 'bg-green-300');
+
+    expect($span->toString())->toBe('<bg=#86efac;options=>with color</>');
+});
+
+it('can receive text-color class names as string', function () {
+    $span = span('with color', 'text-color-green-300');
+
+    expect($span->toString())->toBe('<bg=default;fg=#86efac;options=>with color</>');
+});
+
+it('throws if bg-color class names as string received is not found', function () {
+    expect(
+        fn () => span('with color', 'bg-invalidColor-300')
+    )->toThrow(ColorNotFound::class);
+});
+
+it('throws if text-color class names as string received is not found', function () {
+    expect(
+        fn () => span('with color', 'text-color-invalidColor-300')
+    )->toThrow(ColorNotFound::class);
 });


### PR DESCRIPTION
This PR adds support to handle color variants like TailwindCSS.

Example:

```sh
use function Termwind\span;

span('text', 'bg-green-300 text-color-gray-700')->render();

// or

span('text')->bg('green', 300)->textColor('gray', 700)->render();
```

@nunomaduro if you can double check the exception `ColorNotFound` and the Element function `getColorVariant` not sure if that's the style we want.

Thanks