### PR TITLE
It should not throw `InvalidChild` exception if there is spaces in between elems

### DIFF
--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -33,7 +33,6 @@ final class HtmlRenderer
 
         /** @var DOMNode $body */
         $body = $dom->getElementsByTagName('body')->item(0);
-
         $el = $this->convert($body);
 
         // @codeCoverageIgnoreStart
@@ -53,6 +52,8 @@ final class HtmlRenderer
         foreach ($node->childNodes as $child) {
             $children[] = $this->convert($child);
         }
+
+        $children = array_filter($children, fn ($child) => $child !== '');
 
         return $this->toElement($node, $children);
     }

--- a/tests/ol.php
+++ b/tests/ol.php
@@ -12,3 +12,9 @@ it('renders only "li" as children', function () {
     expect(fn () => parse('<ol><div>list text 1</div></ol>'))
         ->toThrow(InvalidChild::class);
 });
+
+it('renders "li" elements and ignore empty spaces', function () {
+    $html = parse("<ol> <li>list text 1</li>\n\n\n</ol>");
+
+    expect($html)->toBe('<bg=default;options=><bg=default;options=>1. list text 1</></>');
+});

--- a/tests/ul.php
+++ b/tests/ul.php
@@ -12,3 +12,9 @@ it('renders only "li" as children', function () {
     expect(fn () => parse('<ul><div>list text 1</div></ul>'))
         ->toThrow(InvalidChild::class);
 });
+
+it('renders "li" elements and ignore empty spaces', function () {
+    $html = parse("<ul> <li>list text 1</li>\n\n\n</ul>");
+
+    expect($html)->toBe('<bg=default;options=><bg=default;options=>• list text 1</></>');
+});


### PR DESCRIPTION
This PR fixes an issue that I found while rendering an `ul`.

## Example:

```php
render(<<<'HTML'
    <ul>
        <li class='text-color-white'>list item 1</li>
        <li class='text-color-red'>list item 2</li>
    </ul>
HTML);
```

## Error:

```sh
Fatal error: Uncaught Termwind\Exceptions\InvalidChild: Unordered lists only accept `li` as child in src/Termwind.php:88
Stack trace:
#0 [internal function]: Termwind\Termwind::Termwind\{closure}('')
```

Added a test to both `ul` and `ol` to cover this case.