### PR TITLE
Revert "Merge pull request #48 from nunofmmarques/font-light"

### DIFF
--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -63,14 +63,6 @@ abstract class Element
     }
 
     /**
-     * Adds a light style to the element.
-     */
-    final public function fontLight(): static
-    {
-        return $this->with(['options' => ['light']]);
-    }
-
-    /**
      * Adds an italic style to the element.
      */
     final public function italic(): static

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -8,12 +8,6 @@ test('font bold', function () {
     expect($html)->toBe('<bg=default;options=bold>text</>');
 });
 
-test('font light', function () {
-    $html = parse('<div class="font-light">text</div>');
-
-    expect($html)->toBe('<bg=default;options=light>text</>');
-});
-
 test('italic', function () {
     $html = parse('<div class="italic">text</div>');
 


### PR DESCRIPTION
Font Light is not supported via `symfony/console`

## Error:

```sh
Fatal error: Uncaught Symfony\Component\Console\Exception\InvalidArgumentException: Invalid option specified: "light". Expected one of (bold, underscore, blink, reverse, conceal). in vendor/symfony/console/Color.php:63
```

Thanks @nunofmmarques.



