### PR TITLE
fix: Fixes a bug when there are multiple classes of the same type

### DIFF
--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -374,7 +374,7 @@ abstract class Element
      */
     public function with(array $properties): static
     {
-        $properties = array_merge_recursive($this->properties, $properties);
+        $properties = array_replace_recursive($this->properties, $properties);
 
         return new static(
             $this->output,

--- a/tests/render.php
+++ b/tests/render.php
@@ -46,3 +46,11 @@ it('renders element inside another one with extra spaces and line breaks', funct
 
     expect($html)->toBe("<bg=red>Hello \e[1mworld\e[0m</>");
 });
+
+it('renders element and ignores the classes of the same type', function () {
+    $html = parse(<<<'HTML'
+        <div class="ml-3 ml-1">Hello World</div>
+    HTML);
+
+    expect($html)->toBe(' Hello World');
+});


### PR DESCRIPTION
This PR fixes an issue with the `array_merge_recursive`:

if there is something like this:

```php
render(<<<'HTML'
    <div class="ml-3 ml-1">Hello World</div>
HTML);
```

on the toString method the `$properties` return this:

```sh
^ array:2 [
  "isFirstChild" => true
  "styles" => array:2 [
    "ml" => array:2 [
      0 => 3
      1 => 1
    ]
    "display" => "block"
  ]
]
```

the `ml` should not be an array. so the `array_replace_recursive` solves it.