### PR TITLE
Add `defaultStyles` capability to the element

### DIFF
--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -35,7 +35,7 @@ final class StyleToMethod
      */
     public static function multiple(Element $element, string $styles): Element
     {
-        $styles = explode(' ', $styles);
+        $styles = array_merge($element->defaultStyles, explode(' ', $styles));
 
         $styles = array_filter($styles, static function ($style): bool {
             return $style !== '';

--- a/src/Components/Dd.php
+++ b/src/Components/Dd.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Dd extends Element
 {
-    // ..
+    public $defaultStyles = ['block', 'ml-4'];
 }

--- a/src/Components/Div.php
+++ b/src/Components/Div.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Div extends Element
 {
-    // ..
+    public $defaultStyles = ['block'];
 }

--- a/src/Components/Dl.php
+++ b/src/Components/Dl.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Dl extends Element
 {
-    // ..
+    public $defaultStyles = ['block'];
 }

--- a/src/Components/Dt.php
+++ b/src/Components/Dt.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Dt extends Element
 {
-    // ..
+    public $defaultStyles = ['block', 'font-bold'];
 }

--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -16,6 +16,11 @@ use function Termwind\terminal;
 abstract class Element
 {
     /**
+     * @var array<int, string>
+     */
+    public $defaultStyles = [];
+
+    /**
      * Creates an element instance.
      *
      * @param  array<string, mixed>  $properties

--- a/src/Components/Hr.php
+++ b/src/Components/Hr.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Hr extends Element
 {
-    // ..
+    public $defaultStyles = ['block'];
 }

--- a/src/Components/Li.php
+++ b/src/Components/Li.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Li extends Element
 {
-    // ..
+    public $defaultStyles = ['block'];
 }

--- a/src/Components/Ol.php
+++ b/src/Components/Ol.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Ol extends Element
 {
-    // ..
+    public $defaultStyles = ['block'];
 }

--- a/src/Components/Ul.php
+++ b/src/Components/Ul.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Ul extends Element
 {
-    // ..
+    public $defaultStyles = ['block'];
 }

--- a/src/Termwind.php
+++ b/src/Termwind.php
@@ -41,7 +41,7 @@ final class Termwind
 
         return Components\Div::fromStyles(
             self::getRenderer(), $content, $styles, $properties
-        )->block();
+        );
     }
 
     /**
@@ -96,7 +96,7 @@ final class Termwind
 
         return Components\Ul::fromStyles(
             self::getRenderer(), $text, $styles, $properties
-        )->block();
+        );
     }
 
     /**
@@ -118,7 +118,7 @@ final class Termwind
 
         return Components\Ol::fromStyles(
             self::getRenderer(), $text, $styles, $properties
-        )->block();
+        );
     }
 
     /**
@@ -135,7 +135,7 @@ final class Termwind
 
         return Components\Li::fromStyles(
             self::getRenderer(), $content, $styles, $properties
-        )->block();
+        );
     }
 
     /**
@@ -151,16 +151,12 @@ final class Termwind
                 throw new InvalidChild('Description lists only accept `dt` and `dd` as children');
             }
 
-            if ($element instanceof Components\Dt) {
-                return (string) $element;
-            }
-
-            return (string) $element->ml(4);
+            return (string) $element;
         }, $content));
 
         return Components\Dl::fromStyles(
             self::getRenderer(), $text, $styles, $properties
-        )->block();
+        );
     }
 
     /**
@@ -177,7 +173,7 @@ final class Termwind
 
         return Components\Dt::fromStyles(
             self::getRenderer(), $content, $styles, $properties
-        )->fontBold()->block();
+        );
     }
 
     /**
@@ -194,7 +190,7 @@ final class Termwind
 
         return Components\Dd::fromStyles(
             self::getRenderer(), $content, $styles, $properties
-        )->block();
+        );
     }
 
     /**
@@ -208,7 +204,7 @@ final class Termwind
 
         return Components\Hr::fromStyles(
             self::getRenderer(), str_repeat(html_entity_decode('&mdash;'), $width), $styles, $properties
-        )->block();
+        );
     }
 
     /**


### PR DESCRIPTION
This PR adds the capability to add `defaultStyles` to the element.

The way was before it was setting the default at last:

```php
return Components\Dt::fromStyles(
	self::getRenderer(), $content, $styles, $properties
)->fontBold()->block();
```

The way I suggested here, it will always be set at first, so if a default style needs to be overwritten it will work.

Let me know if you have a better approach for this.