### PR TITLE
Add list style type classes

### DIFF
--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -83,6 +83,8 @@ final class StyleToMethod
             return $this->__invoke(...$arguments);
         }
 
-        return $this->element->$methodName(...array_reverse($arguments));
+        return $this->element
+            ->setStyle($this->style)
+            ->$methodName(...array_reverse($arguments));
     }
 }

--- a/src/Components/Ol.php
+++ b/src/Components/Ol.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Ol extends Element
 {
-    public $defaultStyles = ['block'];
+    public $defaultStyles = ['block', 'list-decimal'];
 }

--- a/src/Components/Ul.php
+++ b/src/Components/Ul.php
@@ -6,5 +6,5 @@ namespace Termwind\Components;
 
 final class Ul extends Element
 {
-    public $defaultStyles = ['block'];
+    public $defaultStyles = ['block', 'list-disc'];
 }

--- a/src/Termwind.php
+++ b/src/Termwind.php
@@ -86,17 +86,25 @@ final class Termwind
      */
     public static function ul(array $content = [], string $styles = '', array $properties = []): Components\Ul
     {
-        $text = implode('', array_map(function ($element): string {
-            if (! $element instanceof Components\Li) {
+        $ul = Components\Ul::fromStyles(
+            self::getRenderer(), '', $styles, $properties
+        );
+
+        $content = implode('', array_map(function ($li) use ($ul): string {
+            if (! $li instanceof Components\Li) {
                 throw new InvalidChild('Unordered lists only accept `li` as child');
             }
 
-            return (string) $element->prepend('• ');
+            return (string) match (true) {
+                $li->hasStyle('list-none') => $li,
+                $ul->hasStyle('list-none') => $li->addStyle('list-none'),
+                $ul->hasStyle('list-square') => $li->addStyle('list-square'),
+                $ul->hasStyle('list-disc') => $li->addStyle('list-disc'),
+                default => $li->addStyle('list-none'),
+            };
         }, $content));
 
-        return Components\Ul::fromStyles(
-            self::getRenderer(), $text, $styles, $properties
-        );
+        return $ul->setContent($content);
     }
 
     /**
@@ -107,18 +115,25 @@ final class Termwind
      */
     public static function ol(array $content = [], string $styles = '', array $properties = []): Components\Ol
     {
+        $ol = Components\Ol::fromStyles(
+            self::getRenderer(), '', $styles, $properties
+        );
+
         $index = 0;
-        $text = implode('', array_map(function ($element) use (&$index): string {
-            if (! $element instanceof Components\Li) {
+        $content = implode('', array_map(function ($li) use ($ol, &$index): string {
+            if (! $li instanceof Components\Li) {
                 throw new InvalidChild('Ordered lists only accept `li` as child');
             }
 
-            return (string) $element->prepend(sprintf('%s. ', ++$index));
+            return (string) match (true) {
+                $li->hasStyle('list-none') => $li->addStyle('list-none'),
+                $ol->hasStyle('list-none') => $li->addStyle('list-none'),
+                $ol->hasStyle('list-decimal') => $li->addStyle('list-decimal-' . (++$index)),
+                default => $li->addStyle('list-none'),
+            };
         }, $content));
 
-        return Components\Ol::fromStyles(
-            self::getRenderer(), $text, $styles, $properties
-        );
+        return $ol->setContent($content);
     }
 
     /**

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -198,6 +198,30 @@ test('block', function () {
     expect($html)->toBe("Hello \nWorld");
 });
 
+test('list-disc', function () {
+    $html = parse('<ul class="list-disc"><li>Hello World</li></ul>');
+
+    expect($html)->toBe('• Hello World');
+});
+
+test('list-square', function () {
+    $html = parse('<ul class="list-square"><li>Hello World</li></ul>');
+
+    expect($html)->toBe('▪ Hello World');
+});
+
+test('list-decimal', function () {
+    $html = parse('<ol class="list-decimal"><li>Hello World</li></ol>');
+
+    expect($html)->toBe('1. Hello World');
+});
+
+test('list-none', function () {
+    $html = parse('<ul class="list-none"><li>Hello World</li></ul>');
+
+    expect($html)->toBe('Hello World');
+});
+
 test('Invalid use of style list-none', function () {
     expect(fn () => parse('<span class="list-none">Hello <span>World</span></span>'))
         ->toThrow(InvalidStyle::class);


### PR DESCRIPTION
This PR refactors part of the PR #72 and adds the capability to use other list style type options:

https://tailwindcss.com/docs/list-style-type

Also you can add `list-none` directly to an `Li` element to overwrite the default style from the `ul` and `ol`

### Example:

```php
render(<<<'HTML'
    <ul class="list-square">
        <li>list text 1</li>
        <li>list text 2</li>
        <li class="list-none">list text 3</li>
    </ul>
HTML);
```

### Output

```sh
▪ list text 1
▪ list text 2
list text 3
```

Also added to the `element` class a `styles` property to save all the styles added to each `element` and added the methods `setContent`, `setStyle`, `addStyle` and `hasStyle` to take care of the inherit from the `ul` and `ol`.

Not really sure if the track of styles added is the best option, let me know what do you think @nunomaduro.