### PR TITLE
fix: Inline elements should not be trimmed if there is another sibling

### DIFF
--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -99,10 +99,17 @@ final class HtmlRenderer
     private function toElement(DOMNode $node, array $children): Components\Element|string
     {
         if ($node instanceof DOMText) {
-            $trimmedText = ltrim($node->textContent);
-            $text = preg_replace('/\s+/', ' ', $trimmedText);
+            $text = preg_replace('/\s+/', ' ', $node->textContent) ?? '';
 
-            return is_string($text) ? $text : $trimmedText;
+            if (is_null($node->previousSibling)) {
+                $text = ltrim($text);
+            }
+
+            if (is_null($node->nextSibling)) {
+                $text = rtrim($text);
+            }
+
+            return $text;
         }
 
         /** @var array<string, mixed> $properties */

--- a/src/Termwind.php
+++ b/src/Termwind.php
@@ -101,6 +101,10 @@ final class Termwind
         );
 
         $content = implode('', array_map(function ($li) use ($ul): string {
+            if (is_string($li) && preg_replace('/\s+/', '', $li) === '') {
+                return '';
+            }
+
             if (! $li instanceof Components\Li) {
                 throw new InvalidChild('Unordered lists only accept `li` as child');
             }
@@ -131,6 +135,10 @@ final class Termwind
 
         $index = 0;
         $content = implode('', array_map(function ($li) use ($ol, &$index): string {
+            if (is_string($li) && preg_replace('/\s+/', '', $li) === '') {
+                return '';
+            }
+
             if (! $li instanceof Components\Li) {
                 throw new InvalidChild('Ordered lists only accept `li` as child');
             }
@@ -172,6 +180,10 @@ final class Termwind
     public static function dl(array $content = [], string $styles = '', array $properties = []): Components\Dl
     {
         $text = implode('', array_map(function ($element): string {
+            if (is_string($element) && preg_replace('/\s+/', '', $element) === '') {
+                return '';
+            }
+
             if (! $element instanceof Components\Dt && ! $element instanceof Components\Dd) {
                 throw new InvalidChild('Description lists only accept `dt` and `dd` as children');
             }

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -71,7 +71,7 @@ test('truncate', function () {
         </span>
     HTML);
 
-    expect($html)->toBe('te...text text');
+    expect($html)->toBe('te... text text');
 });
 
 test('width', function () {
@@ -82,7 +82,7 @@ test('width', function () {
         </span>
     HTML);
 
-    expect($html)->toBe('text-text text ');
+    expect($html)->toBe('text- text text ');
 });
 
 test('ml', function () {

--- a/tests/div.php
+++ b/tests/div.php
@@ -1,7 +1,5 @@
 <?php
 
-use function Termwind\{div};
-
 it('renders the element', function () {
     $html = parse('<div>text</div>');
 
@@ -16,5 +14,5 @@ it('renders the element with display block as default', function () {
         </div>
     HTML);
 
-    expect($html)->toBe("\nSecond Line");
+    expect($html)->toBe(" \nSecond Line");
 });

--- a/tests/render.php
+++ b/tests/render.php
@@ -2,15 +2,14 @@
 
 use function Termwind\{render};
 
-it('can render complext html', function () {
+it('can render complex html', function () {
     $html = parse(<<<'HTML'
-<div class="bg-white">
-    <a class="ml-2">link text</a>
-    <a class="ml-2" href="link">link text</a>
-</div>
-HTML);
+        <div class="bg-white">
+            <a class="ml-2">link text</a> and <a href="link">link text</a>
+        </div>
+    HTML);
 
-    expect($html)->toBe('<bg=white>  link text  <href=link>link text</></>');
+    expect($html)->toBe('<bg=white>  link text and <href=link>link text</></>');
 });
 
 it('can render strings', function () {
@@ -22,8 +21,7 @@ it('can render strings', function () {
 it('can render to custom output', function () {
     $html = render(<<<'HTML'
         <div class="bg-white">
-            <a class="ml-2">link text</a>
-            <a class="ml-2" href="link">link text</a>
+            <a class="ml-2">link text</a><a class="ml-2" href="link">link text</a>
         </div>
     HTML);
 
@@ -40,11 +38,11 @@ it('renders element inside another one with extra spaces and line breaks', funct
     $html = parse(<<<'HTML'
         <div class="bg-red">
             Hello
-            <strong>world</strong>
+            <strong>world</strong> <a href="#">click here</a>
         </div>
     HTML);
 
-    expect($html)->toBe("<bg=red>Hello \e[1mworld\e[0m</>");
+    expect($html)->toBe("<bg=red>Hello \e[1mworld\e[0m <href=#>click here</></>");
 });
 
 it('renders element and ignores the classes of the same type', function () {


### PR DESCRIPTION
This PR solves the issue of trimming the text content, and adds a space between the elements if needed, HTML works the same way.

## Example:

```php
render(<<<'HTML'
    <div>
        <a class="ml-2">link text</a> and <a href="link">link text</a>
    </div>
HTML);
```

## Before:

```sh
link text andlink text
```

## After:

```sh
link text and link text
```