### PR TITLE
Rename `width` class to `w` and `textColor` to `text`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The `style()` function may be used to add own custom syles.
 ```php
 use function Termwind\{style};
 
-style('btn')->apply('p-4 bg-blue text-color-white');
+style('btn')->apply('p-4 bg-blue text-white');
 
 render('<div class="btn">Click me</div>');
 ```

--- a/playground.php
+++ b/playground.php
@@ -7,7 +7,7 @@ use function Termwind\{render};
 render(<<<'HTML'
     <div>
         <div class="w-full bg-green-300"></div>
-        <div class="text-color-white ml-2">
+        <div class="text-white ml-2">
             🍃 Termwind now supports `w-full`
         </div>
         <div class="w-full bg-green-400"></div>

--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -203,7 +203,7 @@ abstract class Element
     /**
      * Adds a text color to the element.
      */
-    final public function textColor(string $color, int $variant = 0): static
+    final public function text(string $color, int $variant = 0): static
     {
         if ($variant > 0) {
             $color = $this->getColorVariant($color, $variant);

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -52,15 +52,9 @@ test('bg-color', function () {
 });
 
 test('text-color', function () {
-    $html = parse('<div class="text-color-red">text</div>');
+    $html = parse('<div class="text-red">text</div>');
 
     expect($html)->toBe('<fg=red>text</>');
-});
-
-test('text-color-number', function () {
-    $html = parse('<div class="text-color-red-400">text</div>');
-
-    expect($html)->toBe('<fg=#f87171>text</>');
 });
 
 test('truncate', function () {
@@ -163,14 +157,14 @@ test('bg-color-number', function () {
     expect($html)->toBe('<bg=#86efac>text</>');
 });
 
-test('text-color-color-number', function () {
-    $html = parse('<div class="text-color-green-300">text</div>');
+test('text-color-number', function () {
+    $html = parse('<div class="text-green-300">text</div>');
 
     expect($html)->toBe('<fg=#86efac>text</>');
 });
 
-test('invalid text-color-color-number', function () {
-    expect(fn () => parse('<div class="text-color-green-10000">text</div>'))
+test('invalid text-color-number', function () {
+    expect(fn () => parse('<div class="text-green-10000">text</div>'))
         ->toThrow(ColorNotFound::class);
 });
 

--- a/tests/hr.php
+++ b/tests/hr.php
@@ -17,7 +17,7 @@ it('can be styled', function () {
 
     putenv('COLUMNS=10');
 
-    $html = parse('<hr class="text-color-red">');
+    $html = parse('<hr class="text-red">');
 
     expect($html)
         ->toContain($mdash)

--- a/tests/style.php
+++ b/tests/style.php
@@ -4,7 +4,7 @@ use Termwind\Exceptions\StyleNotFound;
 use function Termwind\style;
 
 it('allows the creation of styles', function () {
-    style('btn')->apply('p-4 bg-blue text-color-white');
+    style('btn')->apply('p-4 bg-blue text-white');
 
     $html = parse('<a class="btn">link text</a>');
 

--- a/tests/table.php
+++ b/tests/table.php
@@ -11,7 +11,7 @@ it('can render table without thead, tbody, tfoot to a string', function () {
         <td align="right">Dante Alighieri</td>
     </tr>
     <tr border="1">
-        <th class="bg-blue-400 text-color-red" align="right">9971-5-0210-0</th>
+        <th class="bg-blue-400 text-red" align="right">9971-5-0210-0</th>
         <td>A Tale of Two Cities</td>
         <td align="right">Charles Dickens</td>
     </tr>
@@ -49,7 +49,7 @@ OUT
 it('can render table with thead to a string', function () {
     $html = (new HtmlRenderer())->parse(<<<HTML
 <table>
-    <thead title="Books" class="bg-red text-color-white px-10">
+    <thead title="Books" class="bg-red text-white px-10">
         <tr>
             <th align="right">ISBN</th>
             <th>Title</th>
@@ -62,7 +62,7 @@ it('can render table with thead to a string', function () {
         <td align="right">Dante Alighieri</td>
     </tr>
     <tr border="1">
-        <th class="bg-blue text-color-red" align="right">9971-5-0210-0</th>
+        <th class="bg-blue text-red" align="right">9971-5-0210-0</th>
         <td>A Tale of Two Cities</td>
         <td align="right">Charles Dickens</td>
     </tr>
@@ -102,7 +102,7 @@ OUT
 it('can render table with thead with two rows to a string', function () {
     $html = (new HtmlRenderer())->parse(<<<HTML
 <table>
-    <thead title="Books" class="bg-red text-color-white px-10">
+    <thead title="Books" class="bg-red text-white px-10">
         <tr border="1">
             <th align="right">Hello</th>
             <th>World</th>
@@ -120,7 +120,7 @@ it('can render table with thead with two rows to a string', function () {
         <td align="right">Dante Alighieri</td>
     </tr>
     <tr border="1">
-        <th class="bg-blue text-color-red" align="right">9971-5-0210-0</th>
+        <th class="bg-blue text-red" align="right">9971-5-0210-0</th>
         <td>A Tale of Two Cities</td>
         <td align="right">Charles Dickens</td>
     </tr>
@@ -166,7 +166,7 @@ it('can render table with tfoot to a string', function () {
         <td align="right">Dante Alighieri</td>
     </tr>
     <tr border="1">
-        <th class="bg-blue text-color-red" align="right">9971-5-0210-0</th>
+        <th class="bg-blue text-red" align="right">9971-5-0210-0</th>
         <td>A Tale of Two Cities</td>
         <td align="right">Charles Dickens</td>
     </tr>
@@ -218,7 +218,7 @@ it('can render table with tbody to a string', function () {
             <td align="right">Dante Alighieri</td>
         </tr>
         <tr border="1">
-            <th class="bg-blue text-color-red" align="right">9971-5-0210-0</th>
+            <th class="bg-blue text-red" align="right">9971-5-0210-0</th>
             <td>A Tale of Two Cities</td>
             <td align="right">Charles Dickens</td>
         </tr>
@@ -257,7 +257,7 @@ OUT
 it('can render table with thead, tbody, tfoot to a string', function () {
     $html = (new HtmlRenderer())->parse(<<<HTML
 <table style="box-double">
-    <thead title="Books" class="bg-red text-color-white px-10">
+    <thead title="Books" class="bg-red text-white px-10">
         <tr>
             <th align="right">ISBN</th>
             <th>Title</th>
@@ -271,7 +271,7 @@ it('can render table with thead, tbody, tfoot to a string', function () {
             <td align="right">Dante Alighieri</td>
         </tr>
         <tr border="1">
-            <th class="bg-blue text-color-red" align="right">9971-5-0210-0</th>
+            <th class="bg-blue text-red" align="right">9971-5-0210-0</th>
             <td>A Tale of Two Cities</td>
             <td align="right">Charles Dickens</td>
         </tr>


### PR DESCRIPTION
This PR renames the methods in order to have the same api from tailwindcss.