### PR TITLE
fix: Fixes problem with empty spaces between two elements

### DIFF
--- a/src/Termwind.php
+++ b/src/Termwind.php
@@ -118,8 +118,8 @@ final class Termwind
         );
 
         $content = implode('', array_map(function ($li) use ($ul): string {
-            if (is_string($li) && preg_replace('/\s+/', '', $li) === '') {
-                return '';
+            if (is_string($li)) {
+                return $li;
             }
 
             if (! $li instanceof Components\Li) {
@@ -152,8 +152,8 @@ final class Termwind
 
         $index = 0;
         $content = implode('', array_map(function ($li) use ($ol, &$index): string {
-            if (is_string($li) && preg_replace('/\s+/', '', $li) === '') {
-                return '';
+            if (is_string($li)) {
+                return $li;
             }
 
             if (! $li instanceof Components\Li) {
@@ -197,8 +197,8 @@ final class Termwind
     public static function dl(array $content = [], string $styles = '', array $properties = []): Components\Dl
     {
         $text = implode('', array_map(function ($element): string {
-            if (is_string($element) && preg_replace('/\s+/', '', $element) === '') {
-                return '';
+            if (is_string($element)) {
+                return $element;
             }
 
             if (! $element instanceof Components\Dt && ! $element instanceof Components\Dd) {

--- a/src/ValueObjects/Node.php
+++ b/src/ValueObjects/Node.php
@@ -194,6 +194,14 @@ final class Node
             return '';
         }
 
+        if ($this->node->nodeValue === ' ') {
+            return ' ';
+        }
+
+        if ($this->isEmpty()) {
+            return '';
+        }
+
         $text = preg_replace('/\s+/', ' ', $this->node->nodeValue) ?? '';
 
         if (is_null($this->getPreviousSibling())) {

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -65,7 +65,7 @@ test('truncate', function () {
         </span>
     HTML);
 
-    expect($html)->toBe('te... text text');
+    expect($html)->toBe('te...text text');
 });
 
 test('w', function () {
@@ -76,7 +76,7 @@ test('w', function () {
         </span>
     HTML);
 
-    expect($html)->toBe('text- text text ');
+    expect($html)->toBe('text-text text ');
 });
 
 test('ml', function () {

--- a/tests/div.php
+++ b/tests/div.php
@@ -17,7 +17,6 @@ it('renders the element with display block as default', function () {
     expect($html)->toBe("First line\nSecond Line");
 });
 
-
 it('renders the element with display block [one empty]', function () {
     $html = parse(<<<'HTML'
         <div>

--- a/tests/div.php
+++ b/tests/div.php
@@ -9,10 +9,22 @@ it('renders the element', function () {
 it('renders the element with display block as default', function () {
     $html = parse(<<<'HTML'
         <div>
+            <div>First line</div>
+            <div>Second Line</div>
+        </div>
+    HTML);
+
+    expect($html)->toBe("First line\nSecond Line");
+});
+
+
+it('renders the element with display block [one empty]', function () {
+    $html = parse(<<<'HTML'
+        <div>
             <div></div>
             <div>Second Line</div>
         </div>
     HTML);
 
-    expect($html)->toBe(" \nSecond Line");
+    expect($html)->toBe("\nSecond Line");
 });

--- a/tests/dl.php
+++ b/tests/dl.php
@@ -35,3 +35,13 @@ it('renders "dt" and "dd" elements and ignore empty spaces', function () {
 
     expect($html)->toBe("\e[1mterm\e[0m\n    details\n\e[1manother term\e[0m\n    more details");
 });
+
+
+it('renders "dt" and "dd" in a single row', function () {
+    $html = parse(<<<'HTML'
+<dl> <dt>term</dt> <dd>details</dd> </dl>
+HTML
+    );
+
+    expect($html)->toBe("\e[1mterm\e[0m \n    details ");
+});

--- a/tests/dl.php
+++ b/tests/dl.php
@@ -36,7 +36,6 @@ it('renders "dt" and "dd" elements and ignore empty spaces', function () {
     expect($html)->toBe("\e[1mterm\e[0m\n    details\n\e[1manother term\e[0m\n    more details");
 });
 
-
 it('renders "dt" and "dd" in a single row', function () {
     $html = parse(<<<'HTML'
 <dl> <dt>term</dt> <dd>details</dd> </dl>

--- a/tests/node.php
+++ b/tests/node.php
@@ -23,3 +23,39 @@ it('it should return bar for dom element', function () {
 
     expect($node->getAttribute('foo'))->toBe('bar');
 });
+
+it('gets next sibling node with empty text', function () {
+    $dom = new DOMDocument();
+
+    $html = '<?xml encoding="UTF-8"><body><div></div>     <div></div></body>';
+    $dom->loadHTML($html, LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_NOBLANKS | LIBXML_NOXMLDECL);
+
+    $body = $dom->getElementsByTagName('body')->item(0);
+    $node = new Node($body->firstChild);
+
+    expect($node->getNextSibling()->getNextSibling())->toBeNull();
+});
+
+it('gets next sibling node with empty line', function () {
+    $dom = new DOMDocument();
+
+    $html = "<?xml encoding=\"UTF-8\"><body><div></div>\n<div></div></body>";
+    $dom->loadHTML($html, LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_NOBLANKS | LIBXML_NOXMLDECL);
+
+    $body = $dom->getElementsByTagName('body')->item(0);
+    $node = new Node($body->firstChild);
+
+    expect($node->getNextSibling()->getNextSibling())->toBeNull();
+});
+
+it('gets next sibling node with comment', function () {
+    $dom = new DOMDocument();
+
+    $html = "<?xml encoding=\"UTF-8\"><body><div></div><!-- Hello world --><div></div></body>";
+    $dom->loadHTML($html, LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_NOBLANKS | LIBXML_NOXMLDECL);
+
+    $body = $dom->getElementsByTagName('body')->item(0);
+    $node = new Node($body->firstChild);
+
+    expect($node->getNextSibling()->getNextSibling())->toBeNull();
+});

--- a/tests/node.php
+++ b/tests/node.php
@@ -51,7 +51,7 @@ it('gets next sibling node with empty line', function () {
 it('gets next sibling node with comment', function () {
     $dom = new DOMDocument();
 
-    $html = "<?xml encoding=\"UTF-8\"><body><div></div><!-- Hello world --><div></div></body>";
+    $html = '<?xml encoding="UTF-8"><body><div></div><!-- Hello world --><div></div></body>';
     $dom->loadHTML($html, LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_NOBLANKS | LIBXML_NOXMLDECL);
 
     $body = $dom->getElementsByTagName('body')->item(0);

--- a/tests/ol.php
+++ b/tests/ol.php
@@ -19,8 +19,24 @@ it('renders "li" elements and ignore empty spaces', function () {
     expect($html)->toBe('1. list text 1');
 });
 
-it('renders "li" elements without style', function () {
-    $html = parse('<ol class="list-none"> <li>list item 1.1 test</li> <li>list item 1.2 test</li> </ol>');
+it('renders "li" elements without style in a single row', function () {
+    $html = parse(<<<'HTML'
+<ol class="list-none"> <li>list item 1.1 test</li> <li>list item 1.2 test</li> <li>list item 1.3 test</li> </ol>
+HTML
+    );
 
-    expect($html)->toBe("list item 1.1 test\nlist item 1.2 test");
+    expect($html)->toBe("list item 1.1 test \nlist item 1.2 test \nlist item 1.3 test ");
+});
+
+it('renders "li" elements without style', function () {
+    $html = parse(<<<'HTML'
+<ol class="list-none">
+    <li>list item 1.1 test</li>
+    <li>list item 1.2 test</li>
+    <li>list item 1.3 test</li>
+</ol>
+HTML
+    );
+
+    expect($html)->toBe("list item 1.1 test\nlist item 1.2 test\nlist item 1.3 test");
 });

--- a/tests/render.php
+++ b/tests/render.php
@@ -37,8 +37,7 @@ it('renders element inside another one', function () {
 it('renders element inside another one with extra spaces and line breaks', function () {
     $html = parse(<<<'HTML'
         <div class="bg-red">
-            Hello
-            <strong>world</strong> <a href="#">click here</a>
+            Hello <strong>world</strong> <a href="#">click here</a>
         </div>
     HTML);
 

--- a/tests/span.php
+++ b/tests/span.php
@@ -7,3 +7,26 @@ it('renders the element', function () {
 
     expect($html)->toBe('text');
 });
+
+it('empty space shouldn\'t be rendered', function () {
+    $html = parse(<<<'HTML'
+<div>
+    <span class="px-1">hello</span>
+    <span class="px-1">world</span>
+</div>
+HTML
+    );
+
+    expect($html)->toBe(' hello  world ');
+});
+
+it('sinlge space shouldn\'t be rendered', function () {
+    $html = parse(<<<'HTML'
+<div>
+    <span class="px-1">hello</span> <span class="px-1">world</span>
+</div>
+HTML
+    );
+
+    expect($html)->toBe(' hello   world ');
+});

--- a/tests/ul.php
+++ b/tests/ul.php
@@ -34,3 +34,12 @@ it('renders "li" elements without style', function () {
 
     expect($html)->toBe("list text 1\nlist text 2");
 });
+
+it('renders "li" elements without style in a single row', function () {
+    $html = parse(<<<'HTML'
+<ul class="list-none"> <li>list item 1.1 test</li> <li>list item 1.2 test</li> <li>list item 1.3 test</li> </ul>
+HTML
+    );
+
+    expect($html)->toBe("list item 1.1 test \nlist item 1.2 test \nlist item 1.3 test ");
+});


### PR DESCRIPTION
```html
<div>
    <span class="px-1">hello</span>
    <span class="px-1">world</span>
</div>
```

Will render
```html
&nbsp;hello&nbsp;&nbsp;world&nbsp;
```

--------

```html
<div>
    <span class="px-1">hello</span> <span class="px-1">world</span>
</div>
```

Will render
```html
&nbsp;hello&nbsp;&nbsp;&nbsp;world&nbsp;
```

fixed #94