### PR TITLE
feat: Adds ability to use styles for pre element

### DIFF
--- a/src/Html/PreRenderer.php
+++ b/src/Html/PreRenderer.php
@@ -8,7 +8,10 @@ use Termwind\Components\Element;
 use Termwind\Termwind;
 use Termwind\ValueObjects\Node;
 
-class PreRenderer
+/**
+ * @internal
+ */
+final class PreRenderer
 {
     /**
      * Gets HTML content from a given node and converts to the content element.

--- a/src/Html/PreRenderer.php
+++ b/src/Html/PreRenderer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Termwind\Html;
+
+use Termwind\Components\Element;
+use Termwind\Termwind;
+use Termwind\ValueObjects\Node;
+use function Termwind\terminal;
+
+class PreRenderer
+{
+    /**
+     * Highlights HTML content from a given node and converts to the content element.
+     */
+    public function toElement(Node $node): Element
+    {
+        $lines = explode("\n", $node->getHtml());
+
+        $maxStrLen = array_reduce(
+            $lines,
+            static fn(int $max, string $line) => ($max < strlen($line)) ? strlen($line) : $max,
+            0
+        ) + 3;
+
+        $styles = $node->getClassAttribute();
+        $html = array_map(
+            static fn(string $line) => (string) Termwind::div(str_pad($line, $maxStrLen), $styles),
+            explode("\n", $node->getHtml())
+        );
+
+        return Termwind::raw(
+            implode('', $html)
+        );
+    }
+}

--- a/src/Html/PreRenderer.php
+++ b/src/Html/PreRenderer.php
@@ -7,27 +7,33 @@ namespace Termwind\Html;
 use Termwind\Components\Element;
 use Termwind\Termwind;
 use Termwind\ValueObjects\Node;
-use function Termwind\terminal;
 
 class PreRenderer
 {
     /**
-     * Highlights HTML content from a given node and converts to the content element.
+     * Gets HTML content from a given node and converts to the content element.
      */
     public function toElement(Node $node): Element
     {
         $lines = explode("\n", $node->getHtml());
+        if (reset($lines) === '') {
+            array_shift($lines);
+        }
+
+        if (end($lines) === '') {
+            array_pop($lines);
+        }
 
         $maxStrLen = array_reduce(
             $lines,
-            static fn(int $max, string $line) => ($max < strlen($line)) ? strlen($line) : $max,
+            static fn (int $max, string $line) => ($max < strlen($line)) ? strlen($line) : $max,
             0
-        ) + 3;
+        );
 
         $styles = $node->getClassAttribute();
         $html = array_map(
-            static fn(string $line) => (string) Termwind::div(str_pad($line, $maxStrLen), $styles),
-            explode("\n", $node->getHtml())
+            static fn (string $line) => (string) Termwind::div(str_pad($line, $maxStrLen + 3), $styles),
+            $lines
         );
 
         return Termwind::raw(

--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -7,6 +7,7 @@ namespace Termwind;
 use DOMDocument;
 use DOMNode;
 use Termwind\Html\CodeRenderer;
+use Termwind\Html\PreRenderer;
 use Termwind\Html\TableRenderer;
 use Termwind\ValueObjects\Node;
 
@@ -56,7 +57,7 @@ final class HtmlRenderer
         } elseif ($node->isName('code')) {
             return (new CodeRenderer)->toElement($node);
         } elseif ($node->isName('pre')) {
-            return Termwind::raw($node->getHtml());
+            return (new PreRenderer)->toElement($node);
         }
 
         foreach ($node->getChildNodes() as $child) {

--- a/tests/pre.php
+++ b/tests/pre.php
@@ -1,7 +1,27 @@
 <?php
 
 it('renders the element', function () {
-    $html = parse('<pre>
+    $content = "    <h1>Introduction</h1>
+
+    <div>The body of your message.</div>
+
+    Thanks,
+    Laravel
+
+    © 2021 Laravel. All rights reserved.";
+
+    $html = parse("<pre>$content</pre>");
+
+    expect($html)->toBe(
+        "\n".implode("\n", array_map(
+            fn(string $line) => str_pad($line, 44),
+            explode("\n", $content)
+        ))
+    );
+});
+
+it('renders the element with styles', function () {
+    $html = parse('<pre class="bg-blue text-red font-bold italic">
     <h1>Introduction</h1>
 
     <div>The body of your message.</div>
@@ -12,14 +32,15 @@ it('renders the element', function () {
     © 2021 Laravel. All rights reserved.
 </pre>');
 
-    expect($html)->toBe('
-    <h1>Introduction</h1>
-
-    <div>The body of your message.</div>
-
-    Thanks,
-    Laravel
-
-    © 2021 Laravel. All rights reserved.
-');
+    expect($html)->toBe("
+<bg=blue;fg=red>\e[3m\e[1m                                            \e[0m\e[0m</>
+<bg=blue;fg=red>\e[3m\e[1m    <h1>Introduction</h1>                   \e[0m\e[0m</>
+<bg=blue;fg=red>\e[3m\e[1m                                            \e[0m\e[0m</>
+<bg=blue;fg=red>\e[3m\e[1m    <div>The body of your message.</div>    \e[0m\e[0m</>
+<bg=blue;fg=red>\e[3m\e[1m                                            \e[0m\e[0m</>
+<bg=blue;fg=red>\e[3m\e[1m    Thanks,                                 \e[0m\e[0m</>
+<bg=blue;fg=red>\e[3m\e[1m    Laravel                                 \e[0m\e[0m</>
+<bg=blue;fg=red>\e[3m\e[1m                                            \e[0m\e[0m</>
+<bg=blue;fg=red>\e[3m\e[1m    © 2021 Laravel. All rights reserved.   \e[0m\e[0m</>
+<bg=blue;fg=red>\e[3m\e[1m                                            \e[0m\e[0m</>");
 });

--- a/tests/pre.php
+++ b/tests/pre.php
@@ -33,7 +33,6 @@ it('renders the element with styles', function () {
 </pre>');
 
     expect($html)->toBe("
-<bg=blue;fg=red>\e[3m\e[1m                                            \e[0m\e[0m</>
 <bg=blue;fg=red>\e[3m\e[1m    <h1>Introduction</h1>                   \e[0m\e[0m</>
 <bg=blue;fg=red>\e[3m\e[1m                                            \e[0m\e[0m</>
 <bg=blue;fg=red>\e[3m\e[1m    <div>The body of your message.</div>    \e[0m\e[0m</>
@@ -41,6 +40,5 @@ it('renders the element with styles', function () {
 <bg=blue;fg=red>\e[3m\e[1m    Thanks,                                 \e[0m\e[0m</>
 <bg=blue;fg=red>\e[3m\e[1m    Laravel                                 \e[0m\e[0m</>
 <bg=blue;fg=red>\e[3m\e[1m                                            \e[0m\e[0m</>
-<bg=blue;fg=red>\e[3m\e[1m    © 2021 Laravel. All rights reserved.   \e[0m\e[0m</>
-<bg=blue;fg=red>\e[3m\e[1m                                            \e[0m\e[0m</>");
+<bg=blue;fg=red>\e[3m\e[1m    © 2021 Laravel. All rights reserved.   \e[0m\e[0m</>");
 });

--- a/tests/pre.php
+++ b/tests/pre.php
@@ -12,15 +12,15 @@ it('renders the element', function () {
 
     $html = parse("<pre>$content</pre>");
 
-    expect($html)->toBe("
-    <h1>Introduction</h1>".str_repeat(' ', 19)."
-".str_repeat(' ', 44)."
-    <div>The body of your message.</div>".str_repeat(' ', 4)."
-".str_repeat(' ', 44)."
-    Thanks,".str_repeat(' ', 33)."
-    Laravel".str_repeat(' ', 33)."
-".str_repeat(' ', 44)."
-    © 2021 Laravel. All rights reserved.".str_repeat(' ', 3)
+    expect($html)->toBe('
+    <h1>Introduction</h1>'.str_repeat(' ', 19).'
+'.str_repeat(' ', 44).'
+    <div>The body of your message.</div>'.str_repeat(' ', 4).'
+'.str_repeat(' ', 44).'
+    Thanks,'.str_repeat(' ', 33).'
+    Laravel'.str_repeat(' ', 33).'
+'.str_repeat(' ', 44).'
+    © 2021 Laravel. All rights reserved.'.str_repeat(' ', 3)
     );
 });
 

--- a/tests/pre.php
+++ b/tests/pre.php
@@ -12,11 +12,15 @@ it('renders the element', function () {
 
     $html = parse("<pre>$content</pre>");
 
-    expect($html)->toBe(
-        "\n".implode("\n", array_map(
-            fn (string $line) => str_pad($line, 44),
-            explode("\n", $content)
-        ))
+    expect($html)->toBe("
+    <h1>Introduction</h1>".str_repeat(' ', 19)."
+".str_repeat(' ', 44)."
+    <div>The body of your message.</div>".str_repeat(' ', 4)."
+".str_repeat(' ', 44)."
+    Thanks,".str_repeat(' ', 33)."
+    Laravel".str_repeat(' ', 33)."
+".str_repeat(' ', 44)."
+    © 2021 Laravel. All rights reserved.".str_repeat(' ', 3)
     );
 });
 

--- a/tests/pre.php
+++ b/tests/pre.php
@@ -1,20 +1,20 @@
 <?php
 
 it('renders the element', function () {
-    $content = "    <h1>Introduction</h1>
+    $content = '    <h1>Introduction</h1>
 
     <div>The body of your message.</div>
 
     Thanks,
     Laravel
 
-    © 2021 Laravel. All rights reserved.";
+    © 2021 Laravel. All rights reserved.';
 
     $html = parse("<pre>$content</pre>");
 
     expect($html)->toBe(
         "\n".implode("\n", array_map(
-            fn(string $line) => str_pad($line, 44),
+            fn (string $line) => str_pad($line, 44),
             explode("\n", $content)
         ))
     );


### PR DESCRIPTION
We can try to add styles for every line inside pre element
```html
<pre class="bg-blue text-red font-bold">
    <h1>Introduction</h1>

    <div>The body of your message.</div>

    Thanks,
    Laravel

    © 2021 Laravel. All rights reserved.
</pre>
```

There is a problem with line width. If I didn't pay attention to the line width, I got something like this

![image](https://user-images.githubusercontent.com/773481/139558311-8bbc3755-eda2-4615-be5f-5a300d384e2e.png)

Then I decided to get width for the longest line in a html and apply `str_pad` function to every line. 

![image](https://user-images.githubusercontent.com/773481/139558214-9884dd90-9d96-477f-926d-aa7146a5a48c.png)

fixed #91