### PR TITLE
fix: Fixes the string content to not be a `<p>` tag

### DIFF
--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -31,6 +31,10 @@ final class HtmlRenderer
     {
         $dom = new DOMDocument();
 
+        if (strip_tags($html) === $html) {
+            return Termwind::span($html);
+        }
+
         $html = '<?xml encoding="UTF-8">'.trim($html);
         $dom->loadHTML($html, LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_NOBLANKS | LIBXML_NOXMLDECL);
 

--- a/tests/render.php
+++ b/tests/render.php
@@ -15,7 +15,7 @@ it('can render complex html', function () {
 it('can render strings', function () {
     $html = parse('text');
 
-    expect($html)->toBe("\ntext\n");
+    expect($html)->toBe("text");
 });
 
 it('can render to custom output', function () {

--- a/tests/render.php
+++ b/tests/render.php
@@ -15,7 +15,7 @@ it('can render complex html', function () {
 it('can render strings', function () {
     $html = parse('text');
 
-    expect($html)->toBe("text");
+    expect($html)->toBe('text');
 });
 
 it('can render to custom output', function () {


### PR DESCRIPTION
This PR fixes the issue #90.

No longer converts a string to a `<p>` tag.