### PR TITLE
feat: Add `setColors` 

### DIFF
--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -9,6 +9,7 @@ use Termwind\Actions\StyleToMethod;
 use Termwind\Enums\Color;
 use Termwind\Exceptions\ColorNotFound;
 use Termwind\Exceptions\InvalidStyle;
+use Termwind\Repositories\Styles;
 use function Termwind\terminal;
 
 /**
@@ -57,11 +58,9 @@ abstract class Element
      */
     final public function bg(string $color, int $variant = 0): static
     {
-        if ($variant > 0) {
-            $color = $this->getColorVariant($color, $variant);
-        }
-
-        return $this->with(['colors' => ['bg' => $color]]);
+        return $this->with(['colors' => [
+            'bg' => $this->getColorVariant($color, $variant),
+        ]]);
     }
 
     /**
@@ -205,12 +204,8 @@ abstract class Element
      */
     final public function text(string $color, int $variant = 0): static
     {
-        if ($variant > 0) {
-            $color = $this->getColorVariant($color, $variant);
-        }
-
         return $this->with(['colors' => [
-            'fg' => $color,
+            'fg' => $this->getColorVariant($color, $variant),
         ]]);
     }
 
@@ -529,7 +524,15 @@ abstract class Element
      */
     private function getColorVariant(string $color, int $variant): string
     {
-        $colorConstant = mb_strtoupper($color.'_'.$variant, 'UTF-8');
+        if ($variant > 0) {
+            $color .= '-'.$variant;
+        }
+
+        if (Styles::has($color)) {
+            return Styles::get($color)->getColor();
+        }
+
+        $colorConstant = mb_strtoupper(str_replace('-', '_', $color), 'UTF-8');
 
         if (! defined(Color::class."::$colorConstant")) {
             throw new ColorNotFound($colorConstant);

--- a/src/Enums/Color.php
+++ b/src/Enums/Color.php
@@ -6,9 +6,9 @@ namespace Termwind\Enums;
 
 final class Color
 {
-    public const BLACK = '#000';
+    public const BLACK = 'black';
 
-    public const WHITE = '#fff';
+    public const WHITE = 'white';
 
     public const SLATE_50 = '#f8fafc';
     public const SLATE_100 = '#f1f5f9';
@@ -21,6 +21,7 @@ final class Color
     public const SLATE_800 = '#1e293b';
     public const SLATE_900 = '#0f172a';
 
+    public const GRAY = 'gray';
     public const GRAY_50 = '#f9fafb';
     public const GRAY_100 = '#f3f4f6';
     public const GRAY_200 = '#e5e7eb';
@@ -65,6 +66,7 @@ final class Color
     public const STONE_800 = '#292524';
     public const STONE_900 = '#1c1917';
 
+    public const RED = 'red';
     public const RED_50 = '#fef2f2';
     public const RED_100 = '#fee2e2';
     public const RED_200 = '#fecaca';
@@ -76,6 +78,7 @@ final class Color
     public const RED_800 = '#991b1b';
     public const RED_900 = '#7f1d1d';
 
+    public const ORANGE = 'orange';
     public const ORANGE_50 = '#fff7ed';
     public const ORANGE_100 = '#ffedd5';
     public const ORANGE_200 = '#fed7aa';
@@ -98,6 +101,7 @@ final class Color
     public const AMBER_800 = '#92400e';
     public const AMBER_900 = '#78350f';
 
+    public const YELLOW = 'yellow';
     public const YELLOW_50 = '#fefce8';
     public const YELLOW_100 = '#fef9c3';
     public const YELLOW_200 = '#fef08a';
@@ -120,6 +124,7 @@ final class Color
     public const LIME_800 = '#3f6212';
     public const LIME_900 = '#365314';
 
+    public const GREEN = 'green';
     public const GREEN_50 = '#f0fdf4';
     public const GREEN_100 = '#dcfce7';
     public const GREEN_200 = '#bbf7d0';
@@ -153,6 +158,7 @@ final class Color
     public const TEAL_800 = '#115e59';
     public const TEAL_900 = '#134e4a';
 
+    public const CYAN = 'cyan';
     public const CYAN_50 = '#ecfeff';
     public const CYAN_100 = '#cffafe';
     public const CYAN_200 = '#a5f3fc';
@@ -175,6 +181,7 @@ final class Color
     public const SKY_800 = '#075985';
     public const SKY_900 = '#0c4a6e';
 
+    public const BLUE = 'blue';
     public const BLUE_50 = '#eff6ff';
     public const BLUE_100 = '#dbeafe';
     public const BLUE_200 = '#bfdbfe';
@@ -251,4 +258,6 @@ final class Color
     public const ROSE_700 = '#be123c';
     public const ROSE_800 = '#9f1239';
     public const ROSE_900 = '#881337';
+
+    public const MAGENTA = 'magenta';
 }

--- a/src/Exceptions/InvalidColor.php
+++ b/src/Exceptions/InvalidColor.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Termwind\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * @internal
+ */
+final class InvalidColor extends InvalidArgumentException
+{
+}

--- a/src/ValueObjects/Style.php
+++ b/src/ValueObjects/Style.php
@@ -6,6 +6,7 @@ namespace Termwind\ValueObjects;
 
 use Closure;
 use Termwind\Actions\StyleToMethod;
+use Termwind\Exceptions\InvalidColor;
 use Termwind\Components\Element;
 
 /**
@@ -18,7 +19,7 @@ final class Style
      *
      * @param Closure(Element $element, string|int ...$argument): Element  $callback
      */
-    public function __construct(private Closure $callback)
+    public function __construct(private Closure $callback, private string $color = '')
     {
         // ..
     }
@@ -35,6 +36,26 @@ final class Style
 
             return StyleToMethod::multiple($element, $styles);
         };
+    }
+
+    /**
+     * Sets the color to the style.
+     */
+    public function color(string $color): void
+    {
+        if (preg_match('/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/', $color) < 1) {
+            throw new InvalidColor(sprintf('The color %s is invalid.', $color));
+        }
+
+        $this->color = $color;
+    }
+
+    /**
+     * Gets the color.
+     */
+    public function getColor(): string
+    {
+        return $this->color;
     }
 
     /**

--- a/src/ValueObjects/Style.php
+++ b/src/ValueObjects/Style.php
@@ -6,8 +6,8 @@ namespace Termwind\ValueObjects;
 
 use Closure;
 use Termwind\Actions\StyleToMethod;
-use Termwind\Exceptions\InvalidColor;
 use Termwind\Components\Element;
+use Termwind\Exceptions\InvalidColor;
 
 /**
  * @internal

--- a/tests/colors.php
+++ b/tests/colors.php
@@ -1,0 +1,26 @@
+<?php
+
+use Termwind\Exceptions\InvalidColor;
+use function Termwind\style;
+
+it('allows the creation of colors', function () {
+    style('black')->color('#101010');
+
+    $html = parse('<span class="bg-black text-black">text</span>');
+
+    expect($html)->toBe('<bg=#101010;fg=#101010>text</>');
+});
+
+it('can be used in a style', function () {
+    style('blue-100')->color('#101010');
+    style('btn')->apply('text-blue-100');
+
+    $html = parse('<span class="btn">text</span>');
+
+    expect($html)->toBe('<fg=#101010>text</>');
+});
+
+it('fails to create a color if is invalid', function () {
+    expect(fn () => style('black')->color('#invalidcolor'))
+        ->toThrow(InvalidColor::class);
+});


### PR DESCRIPTION
This PR adds the capability to overwrite existent colors or create new colors.

## Usage:

```php
use function Termwind\{render, setColors};

setColors([
    'blue-300' => '#0133dc',
    'badass' => '#bada55',
]);

render(<<<'HTML'
    <div class="my-1">
        <div class="bg-blue-300">
            Termwind now supports <b>`setColors()`</b>
        </div>
        <div class="mt-1 bg-badass text-black">
            Can be used like this: <b>`setColors(['badass' => '#bada55'])`</b>
        </div>
    </div>
HTML);
```