### PR TITLE
Should always inherit all parent styles

### DIFF
--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -130,10 +130,6 @@ final class Styles
      */
     final public function inheritFromStyles(Styles $styles): self
     {
-        if (! $styles->hasInheritableStyles() || ! $this->hasInheritableStyles()) {
-            return $this;
-        }
-
         foreach (['bg', 'fg'] as $colorType) {
             $value = (array) ($this->properties['colors'][$colorType] ?? []);
             $parentValue = (array) ($styles->properties['colors'][$colorType] ?? []);

--- a/tests/render.php
+++ b/tests/render.php
@@ -10,7 +10,7 @@ it('can render complex html', function () {
     HTML
     );
 
-    expect($html)->toBe('<bg=white>  link text and <href=link;bg=white>link text</></>');
+    expect($html)->toBe('<bg=white>  <bg=white>link text</> and <href=link;bg=white>link text</></>');
 });
 
 it('can render strings', function () {
@@ -53,7 +53,7 @@ it('renders element inside another one with extra spaces and line breaks', funct
     HTML
     );
 
-    expect($html)->toBe("<bg=red>Hello \e[1mworld\e[0m <href=#;bg=red>click here</></>");
+    expect($html)->toBe("<bg=red>Hello <bg=red>\e[1mworld\e[0m</> <href=#;bg=red>click here</></>");
 });
 
 it('renders element and ignores the classes of the same type', function () {
@@ -77,7 +77,7 @@ it('does not render comment html strings', function () {
     expect($html)->toBe('Hello World');
 });
 
-it('inherit styles', function () {
+it('can inherit styles', function () {
     $html = parse(<<<'HTML'
         <div class="bg-red-300 text-white px-10">
             <span class="mr-1">Hello</span>
@@ -86,10 +86,10 @@ it('inherit styles', function () {
     HTML
     );
 
-    expect($html)->toBe("<bg=#fca5a5;fg=white>          Hello <fg=blue;bg=#fca5a5>\e[1mworld\e[0m</>          </>");
+    expect($html)->toBe("<bg=#fca5a5;fg=white>          <bg=#fca5a5;fg=white>Hello</> <fg=blue;bg=#fca5a5>\e[1mworld\e[0m</>          </>");
 });
 
-it('extend colors', function () {
+it('can extend colors', function () {
     $html = parse(<<<'HTML'
         <div class="my-1 ml-3 px-2 bg-green-300 text-black">
             🍃 Termwind now have the capability to <b>extend</b> colors!
@@ -100,7 +100,7 @@ it('extend colors', function () {
     expect($html)->toBe("\n   <bg=#86efac;fg=black>  🍃 Termwind now have the capability to <bg=#86efac;fg=black;options=bold>extend</> colors!  </>\n");
 });
 
-it('complex extend colors', function () {
+it('can extend with multiple childs and colors', function () {
     $html = parse(<<<'HTML'
          <div class="my-1 ml-3 px-2 bg-green-300 text-black">
             Termwind <span class="text-red-500"><span class="text-blue-300">now <span class="text-indigo-500">have</span> the</span> capability</span> to extend colors!
@@ -124,3 +124,4 @@ it('can inherit styles within multiple levels', function () {
     );
 
     expect($html)->toBe("\n  <bg=#b91c1c>       <fg=#93c5fd;bg=#b91c1c><bg=#b91c1c;fg=#93c5fd><bg=#b91c1c;fg=#93c5fd><bg=#b91c1c;fg=#93c5fd;options=bold>Termwind</> is great!</></></>     </>  \n");
+});

--- a/tests/render.php
+++ b/tests/render.php
@@ -110,3 +110,17 @@ it('complex extend colors', function () {
 
     expect($html)->toBe("\n   <bg=#86efac;fg=black>  Termwind <fg=#ef4444;bg=#86efac><fg=#93c5fd;bg=#86efac>now <fg=#6366f1;bg=#86efac>have</> the</> capability</> to extend colors!  </>\n");
 });
+
+it('can inherit styles within multiple levels', function () {
+    $html = parse(<<<'HTML'
+        <div class="bg-red-700 p-5 my-1 mx-2">
+            <div class="text-blue-300 ml-2">
+                <div>
+                    <div><b>Termwind</b> is great!</div>
+                </div>
+            </div>
+        </div>
+    HTML
+    );
+
+    expect($html)->toBe("\n  <bg=#b91c1c>       <fg=#93c5fd;bg=#b91c1c><bg=#b91c1c;fg=#93c5fd><bg=#b91c1c;fg=#93c5fd><bg=#b91c1c;fg=#93c5fd;options=bold>Termwind</> is great!</></></>     </>  \n");


### PR DESCRIPTION
This PR fixes an issue that I found while testing:

```php
<div class="bg-red-700 p-5">
    <div><b>Termwind</b> now supports `w-full`</div>
</div>
```

## Before:
![image](https://user-images.githubusercontent.com/823088/142743096-aab2aee7-0bd4-4dd4-acbb-b6a6bdc052c3.png)

## After:
![image](https://user-images.githubusercontent.com/823088/142743084-dfdeee86-0b8e-4bc8-ad89-2d7b26efffb9.png)
