### PR TITLE
feat: Allows the inheritance for `margin` and `padding`

### DIFF
--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -375,9 +375,9 @@ final class Styles
      */
     final public function w(int|string $width): self
     {
-        $this->textModifiers[__METHOD__] = static function ($text, $styles, $parent) use ($width): string {
+        $this->textModifiers[__METHOD__] = static function ($text, $styles, $parentStyles) use ($width): string {
             if (is_string($width)) {
-                $width = self::calcWidthFromFraction($width, $styles, $parent);
+                $width = self::calcWidthFromFraction($width, $styles, $parentStyles);
             }
 
             $width -= ($styles['pl'] ?? 0) + ($styles['pr'] ?? 0);

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -30,7 +30,7 @@ final class Styles
      * Creates a Style formatter instance.
      *
      * @param  array<string, mixed>  $properties
-     * @param  array<string, Closure(string, array<string, string|int>): string>  $textModifiers
+     * @param  array<string, Closure(string, array<string, string|int>, array<string, int[]>): string>  $textModifiers
      * @param  array<string, Closure(string, array<string, string|int>): string>  $styleModifiers
      * @param  string[]  $defaultStyles
      */
@@ -123,7 +123,11 @@ final class Styles
         return ($this->properties['colors']['bg'] ?? []) !== []
             || ($this->properties['colors']['fg'] ?? []) !== []
             || ($this->properties['options'] ?? []) !== []
-            || ($this->properties['href'] ?? []) !== [];
+            || ($this->properties['href'] ?? []) !== []
+            || ($this->properties['styles']['ml'] ?? 0) > 0
+            || ($this->properties['styles']['mr'] ?? 0) > 0
+            || ($this->properties['styles']['pl'] ?? 0) > 0
+            || ($this->properties['styles']['pr'] ?? 0) > 0;
     }
 
     /**
@@ -131,6 +135,15 @@ final class Styles
      */
     final public function inheritFromStyles(Styles $styles): self
     {
+        foreach (['ml', 'mr', 'pl', 'pr'] as $margin) {
+            $this->properties['parentStyles'][$margin] = array_merge(
+                $this->properties['parentStyles'][$margin] ?? [],
+                $styles->properties['parentStyles'][$margin] ?? []
+            );
+
+            $this->properties['parentStyles'][$margin][] = $styles->properties['styles'][$margin] ?? 0;
+        }
+
         foreach (['bg', 'fg'] as $colorType) {
             $value = (array) ($this->properties['colors'][$colorType] ?? []);
             $parentValue = (array) ($styles->properties['colors'][$colorType] ?? []);
@@ -362,23 +375,12 @@ final class Styles
      */
     final public function w(int|string $width): self
     {
-        if (is_string($width)) {
-            preg_match('/(\d+)\/(\d+)/', $width, $matches);
-
-            if (count($matches) !== 3 || $matches[2] === '0') {
-                throw new InvalidStyle(sprintf('Style [%s] is invalid.', "w-$width"));
-            }
-
-            $width = (int) floor(terminal()->width() * $matches[1] / $matches[2]);
-        }
-
-        $this->textModifiers[__METHOD__] = static function ($text, $styles) use ($width): string {
-            if ($width === terminal()->width()) {
-                $width -= ($styles['ml'] ?? 0) + ($styles['mr'] ?? 0);
+        $this->textModifiers[__METHOD__] = static function ($text, $styles, $parent) use ($width): string {
+            if (is_string($width)) {
+                $width = self::calcWidthFromFraction($width, $styles, $parent);
             }
 
             $width -= ($styles['pl'] ?? 0) + ($styles['pr'] ?? 0);
-
             $length = mb_strlen(preg_replace("/\<[\w=#\/\;,]+\>/", '', $text), 'UTF-8');
 
             if ($length <= $width) {
@@ -402,7 +404,7 @@ final class Styles
      */
     final public function wFull(): static
     {
-        return $this->w(terminal()->width());
+        return $this->w('1/1');
     }
 
     /**
@@ -553,7 +555,11 @@ final class Styles
         $isFirstChild = $this->properties['isFirstChild'] ?? false;
 
         foreach ($this->textModifiers as $modifier) {
-            $content = $modifier($content, $this->properties['styles'] ?? []);
+            $content = $modifier(
+                $content,
+                $this->properties['styles'] ?? [],
+                $this->properties['parentStyles'] ?? []
+            );
         }
 
         foreach ($this->styleModifiers as $modifier) {
@@ -629,5 +635,29 @@ final class Styles
         }
 
         return constant(Color::class."::$colorConstant");
+    }
+
+    /**
+     * Calculates the width based on the fraction provided.
+     *
+     * @param  array<string, int>  $styles
+     * @param  array<string, int[]>  $parentStyles
+     */
+    private static function calcWidthFromFraction(string $fraction, array $styles, array $parentStyles): int
+    {
+        $width = terminal()->width();
+        $width -= array_sum($parentStyles['ml'] ?? []) + array_sum($parentStyles['mr'] ?? []);
+        $width -= array_sum($parentStyles['pl'] ?? []) + array_sum($parentStyles['pr'] ?? []);
+
+        preg_match('/(\d+)\/(\d+)/', $fraction, $matches);
+
+        if (count($matches) !== 3 || $matches[2] === '0') {
+            throw new InvalidStyle(sprintf('Style [%s] is invalid.', "w-$fraction"));
+        }
+
+        $width = (int) floor($width * $matches[1] / $matches[2]);
+        $width -= ($styles['ml'] ?? 0) + ($styles['mr'] ?? 0);
+
+        return $width;
     }
 }

--- a/tests/render.php
+++ b/tests/render.php
@@ -140,5 +140,5 @@ it('can inherit margins and paddings', function () {
         </div>
     HTML);
 
-    expect($html)->toBe("    A       B       ");
+    expect($html)->toBe('    A       B       ');
 });

--- a/tests/render.php
+++ b/tests/render.php
@@ -125,3 +125,20 @@ it('can inherit styles within multiple levels', function () {
 
     expect($html)->toBe("\n  <bg=#b91c1c>       <fg=#93c5fd;bg=#b91c1c><bg=#b91c1c;fg=#93c5fd><bg=#b91c1c;fg=#93c5fd><bg=#b91c1c;fg=#93c5fd;options=bold>Termwind</> is great!</></></>     </>  \n");
 });
+
+it('can inherit margins and paddings', function () {
+    putenv('COLUMNS=20');
+
+    $html = parse(<<<'HTML'
+        <div class="px-1">
+            <div class="mx-1">
+                <div class="mx-1">
+                    <span class="w-1/2 mr-1 px-1">A</span>
+                    <span class="w-1/2 ml-1 px-1">B</span>
+                </div>
+            </div>
+        </div>
+    HTML);
+
+    expect($html)->toBe("    A       B       ");
+});


### PR DESCRIPTION
This PR allows the inheritance for `margin` and `padding`.

## Example:

```php
render(<<<'HTML'
    <div class="px-5 bg-green-600">
        <div class="mx-10 bg-blue-800">
            <span class="mx-5">
                <span class="w-1/2 mr-1 bg-rose-500 px-2">A</span>
                <span class="w-1/2 ml-1 bg-rose-600 px-2 text-right">B</span>
            </span>
        </div>
    </div>
HTML);
```

## Output:

![image](https://user-images.githubusercontent.com/823088/143296753-acdcbd24-4863-4502-94de-bef65c64784c.png)
