### PR TITLE
feat: Add `terminal()->clear()` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ style('btn')->apply('p-4 bg-green-300 text-white');
 render('<div class="btn">Click me</div>');
 ```
 
+### `terminal()`
+
+The `terminal()` function returns an instance of the [Terminal](https://github.com/nunomaduro/termwind/blob/master/src/Terminal.php) class, with the following methods:
+
+* `->width()`: Returns the full width of the terminal.
+* `->height()`: Returns the full height of the terminal.
+* `->clear()`: It clears the terminal screen.
+
 ## Classes Supported
 
 All the classes supported use exactly the same logic that is available on [tailwindcss.com/docs](https://tailwindcss.com/docs).

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Termwind;
 
 use Symfony\Component\Console\Terminal as ConsoleTerminal;
+use Termwind\Termwind;
 
 /**
  * @internal
@@ -38,5 +39,13 @@ final class Terminal
     public function height(): int
     {
         return $this->terminal->getHeight();
+    }
+
+    /**
+     * Clears the terminal screen.
+     */
+    public function clear(): void
+    {
+        Termwind::getRenderer()->write("\ec");
     }
 }

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Termwind;
 
 use Symfony\Component\Console\Terminal as ConsoleTerminal;
-use Termwind\Termwind;
 
 /**
  * @internal

--- a/src/Termwind.php
+++ b/src/Termwind.php
@@ -274,7 +274,7 @@ final class Termwind
     /**
      * Gets the current renderer instance.
      */
-    private static function getRenderer(): OutputInterface
+    public static function getRenderer(): OutputInterface
     {
         return self::$renderer ??= new ConsoleOutput();
     }

--- a/tests/terminal.php
+++ b/tests/terminal.php
@@ -17,3 +17,9 @@ it('can get the height of the terminal', function () {
 
     expect($height)->toBe(30);
 });
+
+it('can clear the screen', function () {
+    terminal()->clear();
+
+    expect($this->output->fetch())->toBe("\ec");
+});


### PR DESCRIPTION
This PR adds a function to allow the terminal to be cleared.

## Example:

```php
use function Termwind\{render, terminal};

terminal()->clear();

render(<<<'HTML'
    <div class="my-2 mx-2 w-full bg-green-500 font-bold text-black text-center">
        Now there is a capability to clear the "messy" terminal screen
    </div>
HTML);
```

## Before:
![image](https://user-images.githubusercontent.com/823088/145144329-32d8ea1f-76c4-4cd1-a081-395e38f0181b.png)

## After:
![image](https://user-images.githubusercontent.com/823088/145144360-01652c9b-ffd6-4812-becc-e69a539215f3.png)

