### PR TITLE
feat: Adds `ask()` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ style('btn')->apply('p-4 bg-green-300 text-white');
 render('<div class="btn">Click me</div>');
 ```
 
+### `ask()`
+
+The `ask()` function may be used prompt the user with a question.
+
+```php
+use function Termwind\{ask};
+
+$answer = ask(<<<HTML
+    <span class="mt-1 ml-2 mr-1 bg-green px-1 text-black">
+        What is your name?
+    </span>
+HTML);
+```
+
+The `return` provided from the ask method will be the answer provided from the user.
+
 ### `terminal()`
 
 The `terminal()` function returns an instance of the [Terminal](https://github.com/nunomaduro/termwind/blob/master/src/Terminal.php) class, with the following methods:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "ergebnis/phpstan-rules": "^0.15.3",
-        "pestphp/pest": "^2.0.0",
+        "pestphp/pest": "^1.21.0",
+        "pestphp/pest-plugin-mock": "^1.0",
         "phpstan/phpstan": "^0.12.99",
         "phpstan/phpstan-strict-rules": "^0.12.11",
         "styleci/cli": "^1.2.0",

--- a/playground.php
+++ b/playground.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__.'/vendor/autoload.php';
 
-use function Termwind\{render};
+use function Termwind\{render, ask};
 
 render(<<<'HTML'
     <div>

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -6,6 +6,7 @@ namespace Termwind;
 
 use Closure;
 use Symfony\Component\Console\Output\OutputInterface;
+use Termwind\Question;
 use Termwind\Repositories\Styles as StyleRepository;
 use Termwind\ValueObjects\Style;
 use Termwind\ValueObjects\Styles;
@@ -49,5 +50,15 @@ if (! function_exists('Termwind\terminal')) {
     function terminal(): Terminal
     {
         return new Terminal;
+    }
+}
+
+if ( !function_exists('Termwind\ask')) {
+    /**
+     * Renders a prompt to the user.
+     */
+    function ask(string $question): string|null
+    {
+        return (new Question)->ask($question);
     }
 }

--- a/src/Helpers/QuestionHelper.php
+++ b/src/Helpers/QuestionHelper.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Termwind\Helpers;
+
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Helper\QuestionHelper as SymfonyQuestionHelper;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * @internal
+ */
+final class QuestionHelper extends SymfonyQuestionHelper
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function writePrompt(OutputInterface $output, Question $question): void
+    {
+        $text = OutputFormatter::escapeTrailingBackslash($question->getQuestion());
+        $output->write($text);
+    }
+}

--- a/src/Question.php
+++ b/src/Question.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Termwind;
+
+use Symfony\Component\Console\Helper\QuestionHelper as SymfonyQuestionHelper;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\StreamableInputInterface;
+use Symfony\Component\Console\Question\Question as SymfonyQuestion;
+use Termwind\Helpers\QuestionHelper;
+use Termwind\HtmlRenderer;
+
+/**
+ * @internal
+ */
+final class Question
+{
+    /**
+     * The streamable input to receive the input from the user.
+     */
+    private static StreamableInputInterface|null $streamableInput;
+
+    /**
+     * An instance of Symfony's question helper.
+     */
+    private SymfonyQuestionHelper $helper;
+
+    public function __construct(SymfonyQuestionHelper $helper = null)
+    {
+        $this->helper = $helper ?? new QuestionHelper();
+    }
+
+    /**
+     * Sets the streamable input implementation.
+     */
+    public static function setStreamableInput(StreamableInputInterface|null $streamableInput): void
+    {
+        self::$streamableInput = $streamableInput ?? new ArgvInput();
+    }
+
+    /**
+     * Gets the streamable input implementation.
+     */
+    public static function getStreamableInput(): StreamableInputInterface
+    {
+        return self::$streamableInput ??= new ArgvInput();
+    }
+
+    /**
+     * Renders a prompt to the user.
+     */
+    public function ask(string $question): string|null
+    {
+        $html = (new HtmlRenderer)->parse($question)->toString();
+
+        return $this->helper->ask(
+            self::getStreamableInput(),
+            Termwind::getRenderer(),
+            new SymfonyQuestion($html)
+        );
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -21,3 +21,17 @@ function parse(string $html): string
 
     return $html->toString();
 }
+
+/**
+ * Gets a input stream resource from a string.
+ *
+ * @return resource
+ */
+function getInputStream(string $input = 'answer')
+{
+    $stream = fopen('php://memory', 'r+', false);
+    fwrite($stream, $input);
+    rewind($stream);
+
+    return $stream;
+}

--- a/tests/ask.php
+++ b/tests/ask.php
@@ -1,0 +1,31 @@
+<?php
+
+use Symfony\Component\Console\Input\StreamableInputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Termwind\Question;
+use function Termwind\ask;
+use function Termwind\renderUsing;
+
+it('receives the answer given from the user', function () {
+    $inputStream = getInputStream('this was the answer');
+    Question::setStreamableInput($input = Mockery::mock(StreamableInputInterface::class));
+
+    $input->shouldReceive('getStream')->once()->andReturn($inputStream);
+    $input->shouldReceive('isInteractive')->once()->andReturn(true);
+
+    $answer = ask('question');
+    expect($answer)->toBe('this was the answer');
+});
+
+it('renders the question with html', function () {
+    $inputStream = getInputStream();
+    Question::setStreamableInput($input = Mockery::mock(StreamableInputInterface::class));
+
+    $input->shouldReceive('getStream')->once()->andReturn($inputStream);
+    $input->shouldReceive('isInteractive')->once()->andReturn(true);
+
+    renderUsing($output = Mockery::mock(OutputInterface::class));
+
+    $output->shouldReceive('write')->once()->with(' <bg=red>Question</>');
+    $answer = ask('<span class="bg-red ml-1">Question</span>');
+});


### PR DESCRIPTION
This PR adds the capability to prompt the user with a question and style it.

# Example:

```php 
use function Termwind\{ask, render};

$answer = ask(<<<HTML
    <span class="mt-1 ml-2 mr-1 bg-green px-1 text-black">What is your name?</span>
HTML);

render("
    <span class='my-1 mx-2'>
        The answer was: <b class='px-1 bg-green text-black'>$answer</b>
    </span>
");
```

# Output:

![image](https://user-images.githubusercontent.com/823088/146584915-3777ec4e-a293-478e-b6d1-26dc6ac1614b.png)


> It does fallback to Pest v1.0 because of the need of the `pest-plugin-mock`.