### PR TITLE
feat: Add support for `py`, `pt` and `pb`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ All the classes supported use exactly the same logic that is available on [tailw
 * **[Text Overflow](https://tailwindcss.com/docs/text-overflow):** `truncate`
 * **[Text Alignment](https://tailwindcss.com/docs/text-align):** `text-left`, `text-center`, `text-right`
 * **[Margin](https://tailwindcss.com/docs/margin):** `m-{margin}`, `ml-{leftMargin}`, `mr-{rightMargin}`, `mt-{topMargin}`, `mb-{bottomMargin}`, `mx-{horizontalMargin}`, `my-{verticalMargin}`.
-* **[Padding](https://tailwindcss.com/docs/padding):** `p-{padding}`, `pl-{leftPadding}`, `pr-{rightPadding}`, `pt-{topPadding}`, `pb-{bottomPadding}`, `px-{horizontalPadding}`.
+* **[Padding](https://tailwindcss.com/docs/padding):** `p-{padding}`, `pl-{leftPadding}`, `pr-{rightPadding}`, `pt-{topPadding}`, `pb-{bottomPadding}`, `px-{horizontalPadding}`, `py-{verticalPadding}`.
 * **[Width](https://tailwindcss.com/docs/width):** `w-{width}`, `w-full`
 * **[Max Width](https://tailwindcss.com/docs/max-width):** `max-w-{width}`
 * **[Visibility](https://tailwindcss.com/docs/visibility):** `invisible`

--- a/playground.php
+++ b/playground.php
@@ -5,11 +5,9 @@ require_once __DIR__.'/vendor/autoload.php';
 use function Termwind\render;
 
 render(<<<'HTML'
-    <div>
-        <div class="w-full bg-green-300"></div>
-        <div class="text-white ml-2">
-            🍃 Termwind now supports `w-full`
+    <div class="my-1 mx-2">
+        <div class="text-white bg-green-800 px-4 py-1">
+            Termwind now supports <b>`py`</b>
         </div>
-        <div class="w-full bg-green-400"></div>
     </div>
 HTML);

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -372,9 +372,8 @@ final class Styles
             throw new InvalidStyle('`border-t` can only be used on an "hr" element.');
         }
 
-        $this->styleModifiers[__METHOD__] = static function ($text, $styles): string {
-            $length = mb_strlen(preg_replace(self::STYLING_REGEX, '', $text), 'UTF-8');
-
+        $this->styleModifiers[__METHOD__] = function ($text, $styles): string {
+            $length = $this->getLength($text);
             if ($length < 1) {
                 $margins = (int) ($styles['ml'] ?? 0) + ($styles['mr'] ?? 0);
 
@@ -706,7 +705,7 @@ final class Styles
         }
 
         $width -= ($styles['pl'] ?? 0) + ($styles['pr'] ?? 0);
-        $length = mb_strlen(preg_replace(self::STYLING_REGEX, '', $content) ?? '', 'UTF-8');
+        $length = $this->getLength($content);
 
         preg_match_all("/\n+/", $content, $matches);
         $width *= count($matches[0] ?? []) + 1;
@@ -756,7 +755,7 @@ final class Styles
 
         $empty = str_replace(
             $content,
-            str_repeat(' ', mb_strlen(preg_replace(self::STYLING_REGEX, '', $content), 'UTF-8')),
+            str_repeat(' ', $this->getLength($content)),
             $formatted
         );
 
@@ -770,13 +769,13 @@ final class Styles
         }
 
         if ($paddingTop > 0) {
-            $items[] = $empty . "\n";
+            $items[] = $empty."\n";
         }
 
         $items[] = $formatted;
 
         if ($paddingBottom > 0) {
-            $items[] = "\n" . $empty;
+            $items[] = "\n".$empty;
         }
 
         if ($marginBottom > 0) {
@@ -784,6 +783,14 @@ final class Styles
         }
 
         return implode('', $items);
+    }
+
+    /**
+     * Get the length of the text provided without the styling tags.
+     */
+    private function getLength(string $text): int
+    {
+        return mb_strlen(preg_replace(self::STYLING_REGEX, '', $text) ?? '', 'UTF-8');
     }
 
     /**

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -324,7 +324,35 @@ final class Styles
      */
     final public function px(int $padding): self
     {
-        return $this->p($padding);
+        return $this->pl($padding)->pr($padding);
+    }
+
+    /**
+     * Adds the given padding top.
+     */
+    final public function pt(int $padding): static
+    {
+        return $this->with(['styles' => [
+            'pt' => $padding,
+        ]]);
+    }
+
+    /**
+     * Adds the given padding bottom.
+     */
+    final public function pb(int $padding): static
+    {
+        return $this->with(['styles' => [
+            'pb' => $padding,
+        ]]);
+    }
+
+    /**
+     * Adds the given vertical padding.
+     */
+    final public function py(int $padding): self
+    {
+        return $this->pt($padding)->pb($padding);
     }
 
     /**
@@ -332,7 +360,7 @@ final class Styles
      */
     final public function p(int $padding): self
     {
-        return $this->pl($padding)->pr($padding);
+        return $this->pt($padding)->pr($padding)->pb($padding)->pl($padding);
     }
 
     /**
@@ -563,9 +591,6 @@ final class Styles
      */
     final public function format(string $content): string
     {
-        $display = $this->properties['styles']['display'] ?? 'inline';
-        $isFirstChild = (bool) $this->properties['isFirstChild'] ?? false;
-
         foreach ($this->textModifiers as $modifier) {
             $content = $modifier(
                 $content,
@@ -580,29 +605,7 @@ final class Styles
             $content = $modifier($content, $this->properties['styles'] ?? []);
         }
 
-        [$marginLeft, $marginRight] = $this->getMargins();
-        [$paddingLeft, $paddingRight] = $this->getPaddings();
-
-        $content = preg_replace('/\r[ \t]?/', "\n",
-            (string) preg_replace(
-                '/\n/',
-                str_repeat(' ', $marginRight + $paddingRight)
-                ."\n".
-                str_repeat(' ', $marginLeft + $paddingLeft),
-            $content)
-        );
-
-        return sprintf(
-            $this->getFormatString(),
-            $display === 'block' && ! $isFirstChild ? "\n" : '',
-            str_repeat("\n", (int) ($this->properties['styles']['mt'] ?? 0)),
-            str_repeat(' ', $marginLeft),
-            str_repeat(' ', $paddingLeft),
-            $content,
-            str_repeat(' ', $paddingRight),
-            str_repeat(' ', $marginRight),
-            str_repeat("\n", (int) ($this->properties['styles']['mb'] ?? 0)),
-        );
+        return $this->applyStyling($content);
     }
 
     /**
@@ -641,10 +644,10 @@ final class Styles
 
         // If there are no styles we don't need extra tags
         if ($styles === []) {
-            return '%s%s%s%s%s%s%s%s';
+            return '%s%s%s%s%s';
         }
 
-        return '%s%s%s<'.implode(';', $styles).'>%s%s%s</>%s%s';
+        return '%s<'.implode(';', $styles).'>%s%s%s</>%s';
     }
 
     /**
@@ -655,8 +658,10 @@ final class Styles
     private function getMargins(): array
     {
         return [
-            $this->properties['styles']['ml'] ?? 0,
+            $this->properties['styles']['mt'] ?? 0,
             $this->properties['styles']['mr'] ?? 0,
+            $this->properties['styles']['mb'] ?? 0,
+            $this->properties['styles']['ml'] ?? 0,
         ];
     }
 
@@ -668,8 +673,10 @@ final class Styles
     private function getPaddings(): array
     {
         return [
-            $this->properties['styles']['pl'] ?? 0,
+            $this->properties['styles']['pt'] ?? 0,
             $this->properties['styles']['pr'] ?? 0,
+            $this->properties['styles']['pb'] ?? 0,
+            $this->properties['styles']['pl'] ?? 0,
         ];
     }
 
@@ -716,6 +723,67 @@ final class Styles
         }
 
         return self::trimText($content, $width);
+    }
+
+    /**
+     * It applies the styling for the content.
+     */
+    private function applyStyling(string $content): string
+    {
+        $display = $this->properties['styles']['display'] ?? 'inline';
+        $isFirstChild = (bool) $this->properties['isFirstChild'] ?? false;
+
+        [$marginTop, $marginRight, $marginBottom, $marginLeft] = $this->getMargins();
+        [$paddingTop, $paddingRight, $paddingBottom, $paddingLeft] = $this->getPaddings();
+
+        $content = (string) preg_replace('/\r[ \t]?/', "\n",
+            (string) preg_replace(
+                '/\n/',
+                str_repeat(' ', $marginRight + $paddingRight)
+                ."\n".
+                str_repeat(' ', $marginLeft + $paddingLeft),
+            $content)
+        );
+
+        $formatted = sprintf(
+            $this->getFormatString(),
+            str_repeat(' ', $marginLeft),
+            str_repeat(' ', $paddingLeft),
+            $content,
+            str_repeat(' ', $paddingRight),
+            str_repeat(' ', $marginRight),
+        );
+
+        $empty = str_replace(
+            $content,
+            str_repeat(' ', mb_strlen(preg_replace(self::STYLING_REGEX, '', $content), 'UTF-8')),
+            $formatted
+        );
+
+        $items = [];
+        if ($display === 'block' && ! $isFirstChild) {
+            $items[] = "\n";
+        }
+
+        if ($marginTop > 0) {
+            $items[] = str_repeat("\n", $marginTop);
+        }
+
+        if ($paddingTop > 0) {
+            $items[] = $empty . "\n";
+        }
+
+        $items[] = $formatted;
+
+        if ($paddingBottom > 0) {
+            $items[] = "\n" . $empty;
+        }
+
+        if ($marginBottom > 0) {
+            $items[] = str_repeat("\n", $marginBottom);
+        }
+
+        return implode('', $items);
     }
 
     /**

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -72,6 +72,11 @@ test('py', function () {
     expect($html)->toBe("    \ntext\n    ");
 });
 
+test('p', function () {
+    $html = parse('<div class="p-1">text</div>');
+    expect($html)->toBe("      \n text \n      ");
+});
+
 test('bg', function () {
     $html = parse('<div class="bg-red">text</div>');
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -55,6 +55,23 @@ test('px', function () {
     expect($html)->toBe('  text  ');
 });
 
+test('pt', function () {
+    $html = parse('<div class="pt-1">text</div>');
+    expect($html)->toBe("    \ntext");
+});
+
+test('pb', function () {
+    $html = parse('<div class="pb-1">text</div>');
+
+    expect($html)->toBe("text\n    ");
+});
+
+test('py', function () {
+    $html = parse('<div class="py-1">text</div>');
+
+    expect($html)->toBe("    \ntext\n    ");
+});
+
 test('bg', function () {
     $html = parse('<div class="bg-red">text</div>');
 

--- a/tests/render.php
+++ b/tests/render.php
@@ -113,7 +113,7 @@ it('can extend with multiple childs and colors', function () {
 
 it('can inherit styles within multiple levels', function () {
     $html = parse(<<<'HTML'
-        <div class="bg-red-700 p-5 my-1 mx-2">
+        <div class="bg-red-700 px-5 my-1 mx-2">
             <div class="text-blue-300 ml-2">
                 <div>
                     <div><b>Termwind</b> is great!</div>

--- a/tests/style.php
+++ b/tests/style.php
@@ -4,7 +4,7 @@ use Termwind\Exceptions\StyleNotFound;
 use function Termwind\style;
 
 it('allows the creation of styles', function () {
-    style('btn')->apply('p-4 bg-blue text-white');
+    style('btn')->apply('px-4 bg-blue text-white');
 
     $html = parse('<a class="btn">link text</a>');
 


### PR DESCRIPTION
This PR adds the support for `padding-top` and `padding-bottom` classes.

## Example:
```php
render(<<<'HTML'
    <div class="my-1 mx-2">
        <div class="text-white bg-green-800 px-4 py-1">
            Termwind now supports <b>`py`</b>
        </div>
    </div>
HTML);
```

## Output:
![image](https://user-images.githubusercontent.com/823088/149144188-d7e4676c-db89-43f4-908b-00609660f996.png)
