### PR TITLE
feat: Add support for `space-y` and `space-x`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ All the classes supported use exactly the same logic that is available on [tailw
 * **[Text Alignment](https://tailwindcss.com/docs/text-align):** `text-left`, `text-center`, `text-right`
 * **[Margin](https://tailwindcss.com/docs/margin):** `m-{margin}`, `ml-{leftMargin}`, `mr-{rightMargin}`, `mt-{topMargin}`, `mb-{bottomMargin}`, `mx-{horizontalMargin}`, `my-{verticalMargin}`.
 * **[Padding](https://tailwindcss.com/docs/padding):** `p-{padding}`, `pl-{leftPadding}`, `pr-{rightPadding}`, `pt-{topPadding}`, `pb-{bottomPadding}`, `px-{horizontalPadding}`, `py-{verticalPadding}`.
+* **[Space](https://tailwindcss.com/docs/space):** `space-y-{space}`, `space-x-{space}`.
 * **[Width](https://tailwindcss.com/docs/width):** `w-{width}`, `w-full`
 * **[Max Width](https://tailwindcss.com/docs/max-width):** `max-w-{width}`
 * **[Visibility](https://tailwindcss.com/docs/visibility):** `invisible`

--- a/playground.php
+++ b/playground.php
@@ -5,9 +5,9 @@ require_once __DIR__.'/vendor/autoload.php';
 use function Termwind\render;
 
 render(<<<'HTML'
-    <div class="my-1 mx-2">
-        <div class="text-white bg-green-800 px-4 py-1">
-            Termwind now supports <b>`py`</b>
+    <div class="my-1 mx-2 text-black">
+        <div class="bg-green-600 px-4 py-1">
+            Termwind now supports `py`, `pt` and `pb`
         </div>
     </div>
 HTML);

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -366,7 +366,7 @@ final class Styles
     }
 
     /**
-     * Adds the given vertical margin to the childs, ignoring the first child
+     * Adds the given vertical margin to the childs, ignoring the first child.
      */
     final public function spaceY(int $space): self
     {
@@ -376,7 +376,7 @@ final class Styles
     }
 
     /**
-     * Adds the given horizontal margin to the childs, ignoring the first child
+     * Adds the given horizontal margin to the childs, ignoring the first child.
      */
     final public function spaceX(int $space): self
     {

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -134,6 +134,7 @@ final class Styles
             || ($this->properties['styles']['pl'] ?? 0) > 0
             || ($this->properties['styles']['pr'] ?? 0) > 0
             || ($this->properties['styles']['width'] ?? 0) > 0
+            || ($this->properties['styles']['space-y'] ?? 0) > 0
             || ($this->properties['styles']['space-x'] ?? 0) > 0;
     }
 
@@ -142,7 +143,7 @@ final class Styles
      */
     final public function inheritFromStyles(Styles $styles): self
     {
-        foreach (['ml', 'mr', 'pl', 'pr', 'width', 'space-x'] as $style) {
+        foreach (['ml', 'mr', 'pl', 'pr', 'width', 'space-y', 'space-x'] as $style) {
             $this->properties['parentStyles'][$style] = array_merge(
                 $this->properties['parentStyles'][$style] ?? [],
                 $styles->properties['parentStyles'][$style] ?? []
@@ -365,7 +366,17 @@ final class Styles
     }
 
     /**
-     * Adds the given margin to the childs, ignoring the first child
+     * Adds the given vertical margin to the childs, ignoring the first child
+     */
+    final public function spaceY(int $space): self
+    {
+        return $this->with(['styles' => [
+            'space-y' => $space,
+        ]]);
+    }
+
+    /**
+     * Adds the given horizontal margin to the childs, ignoring the first child
      */
     final public function spaceX(int $space): self
     {
@@ -668,11 +679,15 @@ final class Styles
     private function getMargins(): array
     {
         $isFirstChild = (bool) $this->properties['isFirstChild'] ?? false;
+
+        $spaceY = $this->properties['parentStyles']['space-y'] ?? [];
+        $spaceY = ! $isFirstChild ? end($spaceY) : 0;
+
         $spaceX = $this->properties['parentStyles']['space-x'] ?? [];
         $spaceX = ! $isFirstChild ? end($spaceX) : 0;
 
         return [
-            $this->properties['styles']['mt'] ?? 0,
+            $spaceY > 0 ? $spaceY : $this->properties['styles']['mt'] ?? 0,
             $this->properties['styles']['mr'] ?? 0,
             $this->properties['styles']['mb'] ?? 0,
             $spaceX > 0 ? $spaceX : $this->properties['styles']['ml'] ?? 0,
@@ -775,6 +790,7 @@ final class Styles
         );
 
         $items = [];
+
         if ($display === 'block' && ! $isFirstChild) {
             $items[] = "\n";
         }

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -133,7 +133,8 @@ final class Styles
             || ($this->properties['styles']['mr'] ?? 0) > 0
             || ($this->properties['styles']['pl'] ?? 0) > 0
             || ($this->properties['styles']['pr'] ?? 0) > 0
-            || ($this->properties['styles']['width'] ?? 0) > 0;
+            || ($this->properties['styles']['width'] ?? 0) > 0
+            || ($this->properties['styles']['space-x'] ?? 0) > 0;
     }
 
     /**
@@ -141,7 +142,7 @@ final class Styles
      */
     final public function inheritFromStyles(Styles $styles): self
     {
-        foreach (['ml', 'mr', 'pl', 'pr', 'width'] as $style) {
+        foreach (['ml', 'mr', 'pl', 'pr', 'width', 'space-x'] as $style) {
             $this->properties['parentStyles'][$style] = array_merge(
                 $this->properties['parentStyles'][$style] ?? [],
                 $styles->properties['parentStyles'][$style] ?? []
@@ -361,6 +362,16 @@ final class Styles
     final public function p(int $padding): self
     {
         return $this->pt($padding)->pr($padding)->pb($padding)->pl($padding);
+    }
+
+    /**
+     * Adds the given margin to the childs, ignoring the first child
+     */
+    final public function spaceX(int $space): self
+    {
+        return $this->with(['styles' => [
+            'space-x' => $space,
+        ]]);
     }
 
     /**
@@ -656,11 +667,15 @@ final class Styles
      */
     private function getMargins(): array
     {
+        $isFirstChild = (bool) $this->properties['isFirstChild'] ?? false;
+        $spaceX = $this->properties['parentStyles']['space-x'] ?? [];
+        $spaceX = ! $isFirstChild ? end($spaceX) : 0;
+
         return [
             $this->properties['styles']['mt'] ?? 0,
             $this->properties['styles']['mr'] ?? 0,
             $this->properties['styles']['mb'] ?? 0,
-            $this->properties['styles']['ml'] ?? 0,
+            $spaceX > 0 ? $spaceX : $this->properties['styles']['ml'] ?? 0,
         ];
     }
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -89,6 +89,18 @@ test('space-x', function () {
     expect($html)->toBe('1  2  3');
 });
 
+test('space-y', function () {
+    $html = parse(<<<HTML
+        <div class="space-y-2">
+            <div>1</div>
+            <div>2</div>
+            <div>3</div>
+        </div>
+    HTML);
+
+    expect($html)->toBe("1\n\n\n2\n\n\n3");
+});
+
 test('bg', function () {
     $html = parse('<div class="bg-red">text</div>');
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -77,6 +77,18 @@ test('p', function () {
     expect($html)->toBe("      \n text \n      ");
 });
 
+test('space-x', function () {
+    $html = parse(<<<HTML
+        <div class="space-x-2">
+            <span>1</span>
+            <span>2</span>
+            <span>3</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('1  2  3');
+});
+
 test('bg', function () {
     $html = parse('<div class="bg-red">text</div>');
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -77,20 +77,8 @@ test('p', function () {
     expect($html)->toBe("      \n text \n      ");
 });
 
-test('space-x', function () {
-    $html = parse(<<<HTML
-        <div class="space-x-2">
-            <span>1</span>
-            <span>2</span>
-            <span>3</span>
-        </div>
-    HTML);
-
-    expect($html)->toBe('1  2  3');
-});
-
 test('space-y', function () {
-    $html = parse(<<<HTML
+    $html = parse(<<<'HTML'
         <div class="space-y-2">
             <div>1</div>
             <div>2</div>
@@ -99,6 +87,18 @@ test('space-y', function () {
     HTML);
 
     expect($html)->toBe("1\n\n\n2\n\n\n3");
+});
+
+test('space-x', function () {
+    $html = parse(<<<'HTML'
+        <div class="space-x-2">
+            <span>1</span>
+            <span>2</span>
+            <span>3</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('1  2  3');
 });
 
 test('bg', function () {


### PR DESCRIPTION
Hey,

This PR adds the support to the `space-y` and `space-x` utility class from tailwind: https://tailwindcss.com/docs/space

## Example

```php
render(<<<'HTML'
    <div class="my-1 mx-2 space-y-1">
        <div class="font-bold uppercase">Title</div>
        <div>Lorem ipsum dolor sit amet, consectetur adipisicing elit</div>
        <div class="text-gray">© 2022</div>
    </div>
HTML);
```

instead of:

```php
render(<<<'HTML'
    <div class="my-1 mx-2">
        <div class="font-bold uppercase">Title</div>
        <div class="mt-1">Lorem ipsum dolor sit amet, consectetur adipisicing elit</div>
        <div class="mt-1 text-gray">© 2022</div>
    </div>
HTML);
```