### PR TITLE
feat: Add `hideOutput` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ The `terminal()` function returns an instance of the [Terminal](https://github.c
 * `->height()`: Returns the full height of the terminal.
 * `->clear()`: It clears the terminal screen.
 
+### `hideOutput()`
+
+The `hideOutput()` function allows to hide the output for the CLI. This can be used while running tests,
+since the CLI output will not be useful.
+
+```php
+use function Termwind\hideOutput;
+
+// With Pest
+beforeEach(fn () => hideOutput());
+
+// With PHPUnit
+class ExampleTest extends TestCase
+{
+    public function setUp(): void
+    {
+        hideOutput();
+    }
+}
+```
+
 ## Classes Supported
 
 All the classes supported use exactly the same logic that is available on [tailwindcss.com/docs](https://tailwindcss.com/docs).

--- a/playground.php
+++ b/playground.php
@@ -6,10 +6,9 @@ use function Termwind\render;
 
 render(<<<'HTML'
     <div class="w-30 max-w-12 bg-green-600">
-        <span class="w-1/2 text-left">
+        <span>
             Left
-        </span>
-        <span class="w-1/2 text-right">
+        </span> <span>
             Right
         </span>
     </div>

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Termwind;
 
 use Closure;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Termwind\Repositories\Styles as StyleRepository;

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Termwind;
 
 use Closure;
-use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Termwind\Repositories\Styles as StyleRepository;
 use Termwind\ValueObjects\Style;
@@ -27,7 +27,7 @@ if (! function_exists('Termwind\hideOutput')) {
      */
     function hideOutput(): void
     {
-        renderUsing(new NullOutput());
+        renderUsing(new BufferedOutput());
     }
 }
 

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Termwind;
 
 use Closure;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Termwind\Repositories\Styles as StyleRepository;
 use Termwind\ValueObjects\Style;
@@ -17,6 +18,16 @@ if (! function_exists('Termwind\renderUsing')) {
     function renderUsing(OutputInterface|null $renderer): void
     {
         Termwind::renderUsing($renderer);
+    }
+}
+
+if (! function_exists('Termwind\hideOutput')) {
+    /**
+     * Hides the output for the CLI.
+     */
+    function hideOutput(): void
+    {
+        renderUsing(new BufferedOutput());
     }
 }
 

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -6,6 +6,7 @@ namespace Termwind;
 
 use Closure;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Termwind\Repositories\Styles as StyleRepository;
 use Termwind\ValueObjects\Style;
@@ -27,7 +28,7 @@ if (! function_exists('Termwind\hideOutput')) {
      */
     function hideOutput(): void
     {
-        renderUsing(new BufferedOutput());
+        renderUsing(new NullOutput());
     }
 }
 

--- a/tests/hideOutput.php
+++ b/tests/hideOutput.php
@@ -2,7 +2,6 @@
 
 use Symfony\Component\Console\Output\NullOutput;
 use function Termwind\hideOutput;
-use function Termwind\renderUsing;
 use Termwind\Termwind;
 
 it('can hide output', function () {

--- a/tests/hideOutput.php
+++ b/tests/hideOutput.php
@@ -1,7 +1,8 @@
 <?php
 use Symfony\Component\Console\Output\BufferedOutput;
 use Termwind\Termwind;
-use function Termwind\{hideOutput, renderUsing};
+use function Termwind\hideOutput;
+use function Termwind\renderUsing;
 
 beforeEach(fn () => renderUsing(null));
 

--- a/tests/hideOutput.php
+++ b/tests/hideOutput.php
@@ -1,11 +1,14 @@
 <?php
 
-use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use function Termwind\hideOutput;
+use function Termwind\renderUsing;
 use Termwind\Termwind;
+
+beforeEach(fn () => renderUsing(null));
 
 it('can hide output', function () {
     hideOutput();
 
-    expect(Termwind::getRenderer())->toBeInstanceOf(NullOutput::class);
+    expect(Termwind::getRenderer())->toBeInstanceOf(BufferedOutput::class);
 });

--- a/tests/hideOutput.php
+++ b/tests/hideOutput.php
@@ -1,0 +1,12 @@
+<?php
+use Symfony\Component\Console\Output\BufferedOutput;
+use Termwind\Termwind;
+use function Termwind\{hideOutput, renderUsing};
+
+beforeEach(fn () => renderUsing(null));
+
+it('can hide output', function () {
+    hideOutput();
+
+    expect(Termwind::getRenderer())->toBeInstanceOf(BufferedOutput::class);
+});

--- a/tests/hideOutput.php
+++ b/tests/hideOutput.php
@@ -1,4 +1,5 @@
 <?php
+
 use Symfony\Component\Console\Output\BufferedOutput;
 use function Termwind\hideOutput;
 use function Termwind\renderUsing;

--- a/tests/hideOutput.php
+++ b/tests/hideOutput.php
@@ -1,14 +1,12 @@
 <?php
 
-use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use function Termwind\hideOutput;
 use function Termwind\renderUsing;
 use Termwind\Termwind;
 
-beforeEach(fn () => renderUsing(null));
-
 it('can hide output', function () {
     hideOutput();
 
-    expect(Termwind::getRenderer())->toBeInstanceOf(BufferedOutput::class);
+    expect(Termwind::getRenderer())->toBeInstanceOf(NullOutput::class);
 });

--- a/tests/hideOutput.php
+++ b/tests/hideOutput.php
@@ -1,8 +1,8 @@
 <?php
 use Symfony\Component\Console\Output\BufferedOutput;
-use Termwind\Termwind;
 use function Termwind\hideOutput;
 use function Termwind\renderUsing;
+use Termwind\Termwind;
 
 beforeEach(fn () => renderUsing(null));
 


### PR DESCRIPTION
This PR adds the `hideOutput` method.

This is an important method to have for testing purposes, since using this, no output will be render on CLI.

## Usage

```php
use function Termwind\hideOutput;

// With Pest
beforeEach(fn () => hideOutput());

// With PHPUnit
class ExampleTest extends TestCase
{
    public function setUp(): void
    {
        hideOutput();
    }
}
```