### PR TITLE
Updates :sparkles:

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,10 @@
     ],
     "require": {
         "php": "^8.0",
+        "ext-gd": "*",
         "ext-mbstring": "*",
-        "symfony/console": "^5.3.0|^6.0.0"
+        "symfony/console": "^5.3.0|^6.0.0",
+        "symfony/mime": "^5.3.0|^6.0.0"
     },
     "require-dev": {
         "ergebnis/phpstan-rules": "^0.15.3",

--- a/src/Html/ImageRenderer.php
+++ b/src/Html/ImageRenderer.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Termwind\Html;
+
+use Symfony\Component\Console\Color;
+use Symfony\Component\Console\Terminal;
+use Termwind\Components\Element;
+use Termwind\Repositories\ImageReader;
+use Termwind\Termwind;
+use Termwind\ValueObjects\Node;
+
+/**
+ * @internal
+ */
+final class ImageRenderer
+{
+    /**
+     * Highlights HTML content from a given node and converts to the content element.
+     */
+    public function toElement(Node $node): Element
+    {
+        $imagePath = $node->getAttribute('image-path');
+
+        $width = max((int)$node->getAttribute('width'), 10);
+
+        $height = max((int)$node->getAttribute('height'), 10);
+
+        $terminal = new Terminal();
+
+        $maxWidth = $width ?? $terminal->getWidth();
+        $maxHeight = $height ?? $terminal->getHeight() * 2 - 4;
+
+        $reader = new ImageReader($imagePath, $maxWidth, $maxHeight);
+
+        [$width, $height] = $reader->getScaledDimensions($maxWidth, $maxHeight);
+
+        $output = '';
+        for ($y = 0; $y < $height; $y += 2) {
+            for ($x = 0; $x < $width; $x++) {
+                $bgColor = $reader->getImagePixel($x, $y)->toHex();
+                $fgColor = $y + 1 >= $height ? 'black' : $reader->getImagePixel($x, $y + 1)->toHex();
+                $output .= (new Color($fgColor, $bgColor))->apply('▄');
+            }
+            $output .= PHP_EOL;
+        }
+
+        return Termwind::raw($output);
+    }
+}

--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -7,6 +7,7 @@ namespace Termwind;
 use DOMDocument;
 use DOMNode;
 use Termwind\Html\CodeRenderer;
+use Termwind\Html\ImageRenderer;
 use Termwind\Html\PreRenderer;
 use Termwind\Html\TableRenderer;
 use Termwind\ValueObjects\Node;
@@ -62,6 +63,8 @@ final class HtmlRenderer
             return (new CodeRenderer)->toElement($node);
         } elseif ($node->isName('pre')) {
             return (new PreRenderer)->toElement($node);
+        } elseif ($node->isName('timage')) {
+            return (new ImageRenderer)->toElement($node);
         }
 
         foreach ($node->getChildNodes() as $child) {

--- a/src/Repositories/ImageReader.php
+++ b/src/Repositories/ImageReader.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace Termwind\Repositories;
+
+use GdImage;
+use JetBrains\PhpStorm\Pure;
+use Symfony\Component\Mime\MimeTypes;
+
+/**
+ * @internal
+ */
+class ImageReader
+{
+    private $image;
+    private string $imagePath;
+
+    public function __construct(string $imagePath, int $maxWidth, int $maxHeight)
+    {
+
+        $inMemoryPath = tempnam("/tmp", $imagePath);
+        $img = file_get_contents($imagePath);
+        file_put_contents($inMemoryPath, $img);
+
+        if (!is_file($inMemoryPath)) {
+            throw new \InvalidArgumentException(sprintf('Image "%s" does not exist', $imagePath));
+        }
+        if (!is_readable($inMemoryPath)) {
+            throw new \InvalidArgumentException(sprintf('Image "%s" is not readable', $imagePath));
+        }
+
+        $this->imagePath = $inMemoryPath;
+        $mimeType = (new MimeTypes())->guessMimeType($inMemoryPath);
+
+        if (null === $mimeType) {
+            throw new \InvalidArgumentException(sprintf('Cannot guess mime type of image "%s"', $imagePath));
+        }
+
+        $image = match ($mimeType) {
+            'image/png' => imagecreatefrompng($inMemoryPath),
+            'image/jpeg' => imagecreatefromjpeg($inMemoryPath),
+            'image/gif' => imagecreatefromgif($inMemoryPath),
+            'image/vnd.wap.wbmp' => imagecreatefromwbmp($inMemoryPath),
+            'image/webp' => imagecreatefromwebp($inMemoryPath),
+            default => throw new \InvalidArgumentException(sprintf('Mime type "%s" is not supported', $mimeType)),
+        };
+        [$width, $height] = getimagesize($this->imagePath);
+        [$newWidth, $newHeight] = $this->getScaledDimensions($maxWidth, $maxHeight);
+
+        $this->image = imagecreatetruecolor($newWidth, $newHeight);
+
+        imagecopyresampled($this->image, $image, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+    }
+
+    /**
+     * @return GdImage|bool
+     */
+    public function getImageInstance(): GdImage|bool
+    {
+        return $this->image;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function getScaledDimensions(int $maxWidth, int $maxHeight): array
+    {
+        [$width, $height] = getimagesize($this->imagePath);
+        return $this->calculate($width, $height, $maxWidth, $maxHeight);
+    }
+
+    /**
+     * @param int $x
+     * @param int $y
+     * @return Rgb
+     */
+    #[Pure] public function getImagePixel(int $x, int $y): Rgb
+    {
+        $rgb = imagecolorat($this->image, $x, $y);
+        $r = ($rgb >> 16) & 0xFF;
+        $g = ($rgb >> 8) & 0xFF;
+        $b = $rgb & 0xFF;
+        return new Rgb($r, $g, $b);
+    }
+
+    public function calculate(int $width, int $height, int $maxWidth, int $maxHeight): array
+    {
+        $ratio = $height / $width;
+
+        $newWidth = min($width, $maxWidth);
+        $newHeight = $newWidth * $ratio;
+
+        if ($newHeight > $maxHeight) {
+            $newWidth = $maxHeight / $ratio;
+            $newHeight = $maxHeight;
+        }
+
+        return [
+            (int)round($newWidth),
+            (int)round($newHeight),
+        ];
+    }
+}

--- a/src/Repositories/Rgb.php
+++ b/src/Repositories/Rgb.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Termwind\Repositories;
+
+/**
+ * This code was originally posted in a comment by @hallboav of this blog post:
+ * https://symfony.com/blog/new-in-symfony-5-2-true-colors-in-the-console
+ *
+ * @internal
+ */
+class Rgb
+{
+    private string $red;
+    private string $green;
+    private string $blue;
+
+    public function __construct(int $red, int $green, int $blue)
+    {
+        $this->red = pack('C', $red);
+        $this->green = pack('C', $green);
+        $this->blue = pack('C', $blue);
+    }
+
+    public function toHex(): string
+    {
+        return sprintf('#%s%s%s', bin2hex($this->red), bin2hex($this->green), bin2hex($this->blue));
+    }
+}


### PR DESCRIPTION
### itable component added

It will accept `image-path` as the required attribute, and `width` and `height` attributes are optional

We can render the local images as well as local images from external URLs too.


```
render(<<<'HTML'
    <timage image-path="~/Downloads/google.jpg" width="30" height="30"></timage>
HTML);
```

```
render(<<<'HTML'
    <timage image-path="~/Downloads/nunomaduro.jpeg" width="30" height="30"></timage>
HTML);
```

**OUTPUT :**
![output](https://user-images.githubusercontent.com/22654104/153257315-7e51d7e5-2d15-482c-8c0c-486f8148fec5.png)

-----------------------------------------

```
render(<<<'HTML'
    <timage 
       image-path="https://www.google.co.in/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png"
       width="30" height="30">
   </timage>
HTML);
```

**OUTPUT :**
![google-external-url](https://user-images.githubusercontent.com/22654104/153257361-2fa88ee6-1bd5-4c6d-a0f7-85187443d087.png)


It's kinda cool and reference taken from : https://github.com/chr-hertel/console-image