### PR TITLE
feat: Add `MediaQuery` Support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,26 @@ All the classes supported use exactly the same logic that is available on [tailw
 * **[Display](https://tailwindcss.com/docs/display):** `block`
 * **[List Style](https://tailwindcss.com/docs/list-style-type):** `list-disc`, `list-decimal`, `list-square`, `list-none`
 
+## Responsive Design
+
+Like TailwindCSS we also support [Responsive Design](https://tailwindcss.com/docs/responsive-design#customizing-breakpoints) media queries and this are the breakpoints supported:
+
+* **`sm`**: 64 spaces (640px)
+* **`md`**: 76 spaces (768px)
+* **`lg`**: 102 spaces (1024px)
+* **`xl`**: 128 spaces (1280px)
+* **`2xl`**: 153 spaces (1536px)
+
+```php
+render(<<<'HTML'
+    <div class="bg-blue-500 sm:bg-red-600">
+        If bg is blue is sm, if red > than sm breakpoint.
+    </div>
+HTML);
+```
+
+All the sizes for the CLI are based on Font Size 15.
+
 ## HTML Elements Supported
 
 All the elements have the capability to use the `class` attribute.

--- a/playground.php
+++ b/playground.php
@@ -2,13 +2,17 @@
 
 require_once __DIR__.'/vendor/autoload.php';
 
-use function Termwind\render;
+use function Termwind\{render, terminal};
 
 render(<<<'HTML'
-    <div>
-        <div class="px-1 bg-green-600">Termwind</div>
-        <em class="ml-1">
-          Give your CLI apps a unique look
-        </em>
+    <div class="mx-2 my-1 space-y-1">
+        <div>
+            <span class="bg-green-500 text-black font-bold px-1">Media Queries with <b>Termwind</b>?</span>
+            <em class="ml-2">Sure, why not?</em>
+        </div>
+
+        <div class="px-1 font-bold bg-blue-500 sm:bg-red-600">
+            If bg is blue is small, if red > than small
+        </div>
     </div>
 HTML);

--- a/playground.php
+++ b/playground.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__.'/vendor/autoload.php';
 
-use function Termwind\{render, terminal};
+use function Termwind\render;
 
 render(<<<'HTML'
     <div class="mx-2 my-1 space-y-1">

--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -6,8 +6,8 @@ namespace Termwind\Actions;
 
 use Termwind\Exceptions\StyleNotFound;
 use Termwind\Repositories\Styles as StyleRepository;
+use Termwind\Terminal;
 use Termwind\ValueObjects\Styles;
-use function Termwind\terminal;
 
 /**
  * @internal
@@ -143,7 +143,7 @@ final class StyleToMethod
 
         [, $size, $method] = $matches;
 
-        if (terminal()->width() >= self::MEDIA_QUERIES_BREAKPOINTS[$size]) {
+        if ((new Terminal)->width() >= self::MEDIA_QUERIES_BREAKPOINTS[$size]) {
             return $method;
         }
 

--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -22,7 +22,7 @@ final class StyleToMethod
     /**
      * Defines the Media Query Breakpoints.
      */
-    public const MEDIA_QUERIES_BREAKPOINTS = [
+    public const MEDIA_QUERY_BREAKPOINTS = [
         'sm' => 64,
         'md' => 76,
         'lg' => 102,
@@ -110,7 +110,7 @@ final class StyleToMethod
      */
     private static function sortStyles(array $styles): array
     {
-        $keys = array_keys(self::MEDIA_QUERIES_BREAKPOINTS);
+        $keys = array_keys(self::MEDIA_QUERY_BREAKPOINTS);
 
         usort($styles, function ($a, $b) use ($keys) {
             $existsA = (bool) preg_match(self::MEDIA_QUERIES_REGEX, $a, $matchesA);
@@ -143,7 +143,7 @@ final class StyleToMethod
 
         [, $size, $method] = $matches;
 
-        if ((new Terminal)->width() >= self::MEDIA_QUERIES_BREAKPOINTS[$size]) {
+        if ((new Terminal)->width() >= self::MEDIA_QUERY_BREAKPOINTS[$size]) {
             return $method;
         }
 

--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -7,12 +7,29 @@ namespace Termwind\Actions;
 use Termwind\Exceptions\StyleNotFound;
 use Termwind\Repositories\Styles as StyleRepository;
 use Termwind\ValueObjects\Styles;
+use function Termwind\terminal;
 
 /**
  * @internal
  */
 final class StyleToMethod
 {
+    /**
+     * Finds if there is any media query on the style class.
+     */
+    private const MEDIA_QUERIES_REGEX = "/^(sm|md|lg|xl|2xl)\:(.*)/";
+
+    /**
+     * Defines the Media Query Breakpoints.
+     */
+    public const MEDIA_QUERIES_BREAKPOINTS = [
+        'sm' => 64,
+        'md' => 76,
+        'lg' => 102,
+        'xl' => 128,
+        '2xl' => 153,
+    ];
+
     /**
      * Creates a new action instance.
      */
@@ -34,6 +51,8 @@ final class StyleToMethod
             return $style !== '';
         });
 
+        $stylesString = self::sortStyles($stylesString);
+
         foreach ($stylesString as $style) {
             $styles = (new self($styles, $style))->__invoke();
         }
@@ -52,11 +71,16 @@ final class StyleToMethod
             return StyleRepository::get($this->style)($this->styles, ...$arguments);
         }
 
-        $method = explode('-', $this->style);
+        $method = $this->applyMediaQuery($this->style);
+
+        if ($method === '') {
+            return $this->styles;
+        }
+
+        $method = explode('-', $method);
         $method = array_slice($method, 0, count($method) - count($arguments));
 
         $methodName = implode(' ', $method);
-
         $methodName = ucwords($methodName);
         $methodName = lcfirst($methodName);
         $methodName = str_replace(' ', '', $methodName);
@@ -76,5 +100,53 @@ final class StyleToMethod
         return $this->styles
             ->setStyle($this->style)
             ->$methodName(...array_reverse($arguments));
+    }
+
+    /**
+     * Sorts all the styles based on the correct render order.
+     *
+     * @param  string[]  $styles
+     * @return string[]
+     */
+    private static function sortStyles(array $styles): array
+    {
+        $keys = array_keys(self::MEDIA_QUERIES_BREAKPOINTS);
+
+        usort($styles, function ($a, $b) use ($keys) {
+            $existsA = (bool) preg_match(self::MEDIA_QUERIES_REGEX, $a, $matchesA);
+            $existsB = (bool) preg_match(self::MEDIA_QUERIES_REGEX, $b, $matchesB);
+
+            if ($existsA && ! $existsB) {
+                return 1;
+            }
+
+            if ($existsA && array_search($matchesA[1], $keys, true) > array_search($matchesB[1], $keys, true)) {
+                return 1;
+            }
+
+            return -1;
+        });
+
+        return $styles;
+    }
+
+    /**
+     * Applies the media query if exists.
+     */
+    public function applyMediaQuery(string $method): string
+    {
+        preg_match(self::MEDIA_QUERIES_REGEX, $method, $matches);
+
+        if (count($matches ?? []) < 1) {
+            return $method;
+        }
+
+        [, $size, $method] = $matches;
+
+        if (terminal()->width() >= self::MEDIA_QUERIES_BREAKPOINTS[$size]) {
+            return $method;
+        }
+
+        return '';
     }
 }

--- a/tests/mediaQueries.php
+++ b/tests/mediaQueries.php
@@ -15,7 +15,7 @@ it('supports styling', function ($name) {
 it('renders based on the size even if the styles are in the wrong order', function () {
     putenv('COLUMNS=64');
 
-    $html = parse(<<<HTML
+    $html = parse(<<<'HTML'
         <div class="md:bg-blue lg:bg-purple sm:bg-red bg-green">
             Test
         </div>

--- a/tests/mediaQueries.php
+++ b/tests/mediaQueries.php
@@ -3,14 +3,14 @@
 use Termwind\Actions\StyleToMethod;
 
 it('supports styling', function ($name) {
-    putenv('COLUMNS='.StyleToMethod::MEDIA_QUERIES_BREAKPOINTS[$name]);
+    putenv('COLUMNS='.StyleToMethod::MEDIA_QUERY_BREAKPOINTS[$name]);
 
     $html = parse(<<<HTML
         <div class="w-full {$name}:w-1"></div>
     HTML);
 
     expect($html)->toBe(' ');
-})->with(array_keys(StyleToMethod::MEDIA_QUERIES_BREAKPOINTS));
+})->with(array_keys(StyleToMethod::MEDIA_QUERY_BREAKPOINTS));
 
 it('renders based on the size even if the styles are in the wrong order', function () {
     putenv('COLUMNS=64');

--- a/tests/mediaQueries.php
+++ b/tests/mediaQueries.php
@@ -3,7 +3,7 @@
 use Termwind\Actions\StyleToMethod;
 
 it('supports styling', function ($name) {
-    putenv('COLUMNS=' . StyleToMethod::MEDIA_QUERIES_BREAKPOINTS[$name]);
+    putenv('COLUMNS='.StyleToMethod::MEDIA_QUERIES_BREAKPOINTS[$name]);
 
     $html = parse(<<<HTML
         <div class="w-full {$name}:w-1"></div>
@@ -22,5 +22,4 @@ it('renders based on the size even if the styles are in the wrong order', functi
     HTML);
 
     expect($html)->toBe('<bg=red>Test</>');
-
 });

--- a/tests/mediaQueries.php
+++ b/tests/mediaQueries.php
@@ -1,0 +1,26 @@
+<?php
+
+use Termwind\Actions\StyleToMethod;
+
+it('supports styling', function ($name) {
+    putenv('COLUMNS=' . StyleToMethod::MEDIA_QUERIES_BREAKPOINTS[$name]);
+
+    $html = parse(<<<HTML
+        <div class="w-full {$name}:w-1"></div>
+    HTML);
+
+    expect($html)->toBe(' ');
+})->with(array_keys(StyleToMethod::MEDIA_QUERIES_BREAKPOINTS));
+
+it('renders based on the size even if the styles are in the wrong order', function () {
+    putenv('COLUMNS=64');
+
+    $html = parse(<<<HTML
+        <div class="md:bg-blue lg:bg-purple sm:bg-red bg-green">
+            Test
+        </div>
+    HTML);
+
+    expect($html)->toBe('<bg=red>Test</>');
+
+});


### PR DESCRIPTION
This PR adds the support for `MediaQueries`.

## Example

```php
render(<<<'HTML'
    <div class="mx-2 my-1 space-y-1">
        <div>
            <span class="bg-green-500 text-black font-bold px-1">Media Queries with <b>Termwind</b>?</span>
            <em class="ml-2">Sure, why not?</em>
        </div>

        <div class="px-1 font-bold bg-blue-500 sm:bg-red-600">
            If bg is blue is small, if red > than small
        </div>
    </div>
HTML);
```

## Result
![image](https://user-images.githubusercontent.com/823088/154681356-7ed2f042-d109-43f8-80e5-7fe519fe5107.png)