### PR TITLE
Feet: Add `justify-around` and `justify-evenly` classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ All the classes supported use exactly the same logic that is available on [tailw
 * **[Space](https://tailwindcss.com/docs/space):** `space-y-{space}`, `space-x-{space}`.
 * **[Width](https://tailwindcss.com/docs/width):** `w-{width}`, `w-full`
 * **[Max Width](https://tailwindcss.com/docs/max-width):** `max-w-{width}`
-* **[Justify Content](https://tailwindcss.com/docs/justify-content):** `justify-between`
+* **[Justify Content](https://tailwindcss.com/docs/justify-content):** `justify-between`, `justify-evenly`
 * **[Visibility](https://tailwindcss.com/docs/visibility):** `invisible`
 * **[Display](https://tailwindcss.com/docs/display):** `block`
 * **[List Style](https://tailwindcss.com/docs/list-style-type):** `list-disc`, `list-decimal`, `list-square`, `list-none`

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ All the classes supported use exactly the same logic that is available on [tailw
 * **[Space](https://tailwindcss.com/docs/space):** `space-y-{space}`, `space-x-{space}`.
 * **[Width](https://tailwindcss.com/docs/width):** `w-{width}`, `w-full`
 * **[Max Width](https://tailwindcss.com/docs/max-width):** `max-w-{width}`
-* **[Justify Content](https://tailwindcss.com/docs/justify-content):** `justify-between`, `justify-evenly`
+* **[Justify Content](https://tailwindcss.com/docs/justify-content):** `justify-between`, `justify-around`, `justify-evenly`
 * **[Visibility](https://tailwindcss.com/docs/visibility):** `invisible`
 * **[Display](https://tailwindcss.com/docs/display):** `block`
 * **[List Style](https://tailwindcss.com/docs/list-style-type):** `list-disc`, `list-decimal`, `list-square`, `list-none`

--- a/playground.php
+++ b/playground.php
@@ -5,14 +5,29 @@ require_once __DIR__.'/vendor/autoload.php';
 use function Termwind\render;
 
 render(<<<'HTML'
-    <div class="mx-2 my-1 space-y-1">
-        <div>
-            <span class="bg-green-500 text-black font-bold px-1">Media Queries with <b>Termwind</b>?</span>
-            <em class="ml-2">Sure, why not?</em>
+    <div class="mx-2 my-1">
+        <div>🍃 Termwind now supports both <span class="px-1 bg-gray-600">justify-between</span>,
+            <span class="px-1 bg-gray-600">justify-around</span> and <span class="px-1 bg-gray-600">justify-evenly</span>.
         </div>
-
-        <div class="px-1 font-bold bg-blue-500 sm:bg-red-600">
-            If bg is blue is small, if red > than small
+        <div class="max-w-61 w-full">
+            <div class="mt-1 font-bold">.justify-between Example</div>
+            <div class="justify-between bg-blue-900">
+                <span class="px-1 bg-blue-400">1</span>
+                <span class="px-1 bg-blue-400">2</span>
+                <span class="px-1 bg-blue-400">3</span>
+            </div>
+            <div class="mt-1 font-bold">.justify-around Example</div>
+            <div class="justify-around bg-purple-900">
+                <span class="px-1 bg-purple-500">1</span>
+                <span class="px-1 bg-purple-500">2</span>
+                <span class="px-1 bg-purple-500">3</span>
+            </div>
+            <div class="mt-1 font-bold">.justify-evenly Example</div>
+            <div class="justify-evenly bg-pink-900">
+                <span class="px-1 bg-pink-500">1</span>
+                <span class="px-1 bg-pink-500">2</span>
+                <span class="px-1 bg-pink-500">3</span>
+            </div>
         </div>
     </div>
 HTML);

--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -70,14 +70,14 @@ final class InheritStyles
             }
 
             $arr = [];
+            $length = floor($justifyEvenly);
             foreach ($elements as $index => &$element) {
-                // Since there is no float pixel, on the last one it should round up...
-                $length = $index === count($elements) - 1 ? ceil($justifyEvenly) : floor($justifyEvenly);
-
                 $arr[] = str_repeat(' ', (int) $length);
                 $arr[] = $element;
 
                 if ($index === count($elements) - 1) {
+                    // Since there is no float pixel, on the last one it should round up...
+                    $length = ceil($justifyEvenly);
                     $arr[] = str_repeat(' ', (int) $length);
                 }
             }

--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -38,6 +38,7 @@ final class InheritStyles
         return match ($styles->getProperties()['styles']['justifyContent'] ?? false) {
             'between' => $this->applyJustifyBetween($elements),
             'evenly' => $this->applyJustifyEvenly($elements),
+            'around' => $this->applyJustifyAround($elements),
             default => $elements,
         };
     }
@@ -88,17 +89,42 @@ final class InheritStyles
         }
 
         $arr = [];
-        $length = floor($space);
         foreach ($elements as $index => &$element) {
-            $arr[] = str_repeat(' ', (int) $length);
+            $arr[] = str_repeat(' ', (int) floor($space));
             $arr[] = $element;
-
-            if ($index === count($elements) - 1) {
-                // Since there is no float pixel, on the last one it should round up...
-                $length = ceil($space);
-                $arr[] = str_repeat(' ', (int) $length);
-            }
         }
+
+        $arr[] = str_repeat(' ', (int) ceil($space));
+
+        return $arr;
+    }
+
+    /**
+     * Applies the space around the elements.
+     *
+     * @param  array<int, Element|string>  $elements
+     * @return array<int, Element|string>
+     */
+    private function applyJustifyAround(array $elements): array
+    {
+        [$totalWidth, $parentWidth] = $this->getWidthFromElements($elements);
+        $space = ($parentWidth - $totalWidth) / count($elements);
+
+        if ($space < 1) {
+            return $elements;
+        }
+
+        $arr = [str_repeat(' ', (int) (floor($space) / 2))];
+
+        foreach ($elements as $index => &$element) {
+            if ($index !== 0) {
+                $arr[] = str_repeat(' ', (int) ceil($space));
+            }
+
+            $arr[] = $element;
+        }
+
+        $arr[] = str_repeat(' ', (int) (floor($space) / 2));
 
         return $arr;
     }

--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -59,6 +59,32 @@ final class InheritStyles
             return $arr;
         }
 
+        if ((bool) ($styles->getProperties()['styles']['justifyEvenly'] ?? false)) {
+            /** @var Element[] $elements */
+            $totalWidth = (int) array_reduce($elements, fn ($carry, $element) => $carry += $element->getLength(), 0);
+            $parentWidth = Styles::getParentWidth($elements[0]->getProperties()['parentStyles'] ?? []);
+            $justifyEvenly = ($parentWidth - $totalWidth) / (count($elements) + 1);
+
+            if ($justifyEvenly < 1) {
+                return $elements;
+            }
+
+            $arr = [];
+            foreach ($elements as $index => &$element) {
+                // Since there is no float pixel, on the last one it should round up...
+                $length = $index === count($elements) - 1 ? ceil($justifyEvenly) : floor($justifyEvenly);
+
+                $arr[] = str_repeat(' ', (int) $length);
+                $arr[] = $element;
+
+                if ($index === count($elements) - 1) {
+                    $arr[] = str_repeat(' ', (int) $length);
+                }
+            }
+
+            return $arr;
+        }
+
         return $elements;
     }
 }

--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -89,7 +89,7 @@ final class InheritStyles
         }
 
         $arr = [];
-        foreach ($elements as $index => &$element) {
+        foreach ($elements as &$element) {
             $arr[] = str_repeat(' ', (int) floor($space));
             $arr[] = $element;
         }

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -136,8 +136,7 @@ final class Styles
             || ($this->properties['styles']['width'] ?? 0) > 0
             || ($this->properties['styles']['spaceY'] ?? 0) > 0
             || ($this->properties['styles']['spaceX'] ?? 0) > 0
-            || ($this->properties['styles']['justifyBetween'] ?? false) === true
-            || ($this->properties['styles']['justifyEvenly'] ?? false) === true;
+            || ($this->properties['styles']['justifyContent'] ?? false) !== false;
     }
 
     /**
@@ -154,8 +153,7 @@ final class Styles
             $this->properties['parentStyles'][$style][] = $styles->properties['styles'][$style] ?? 0;
         }
 
-        $this->properties['parentStyles']['justifyBetween'] = $styles->properties['styles']['justifyBetween'] ?? false;
-        $this->properties['parentStyles']['justifyEvenly'] = $styles->properties['styles']['justifyEvenly'] ?? false;
+        $this->properties['parentStyles']['justifyContent'] = $styles->properties['styles']['justifyContent'] ?? false;
 
         foreach (['bg', 'fg'] as $colorType) {
             $value = (array) ($this->properties['colors'][$colorType] ?? []);
@@ -554,7 +552,7 @@ final class Styles
     final public function justifyBetween(): self
     {
         return $this->with(['styles' => [
-            'justifyBetween' => true,
+            'justifyContent' => 'between',
         ]]);
     }
 
@@ -564,7 +562,7 @@ final class Styles
     final public function justifyEvenly(): self
     {
         return $this->with(['styles' => [
-            'justifyEvenly' => true,
+            'justifyContent' => 'evenly',
         ]]);
     }
 

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -557,6 +557,17 @@ final class Styles
     }
 
     /**
+     * Justifies childs along the element with an equal amount of space between
+     * each item and half around.
+     */
+    final public function justifyAround(): self
+    {
+        return $this->with(['styles' => [
+            'justifyContent' => 'around',
+        ]]);
+    }
+
+    /**
      * Justifies childs along the element with an equal amount of space around each item.
      */
     final public function justifyEvenly(): self

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -136,7 +136,8 @@ final class Styles
             || ($this->properties['styles']['width'] ?? 0) > 0
             || ($this->properties['styles']['spaceY'] ?? 0) > 0
             || ($this->properties['styles']['spaceX'] ?? 0) > 0
-            || ($this->properties['styles']['justifyBetween'] ?? false) === true;
+            || ($this->properties['styles']['justifyBetween'] ?? false) === true
+            || ($this->properties['styles']['justifyEvenly'] ?? false) === true;
     }
 
     /**
@@ -154,6 +155,7 @@ final class Styles
         }
 
         $this->properties['parentStyles']['justifyBetween'] = $styles->properties['styles']['justifyBetween'] ?? false;
+        $this->properties['parentStyles']['justifyEvenly'] = $styles->properties['styles']['justifyEvenly'] ?? false;
 
         foreach (['bg', 'fg'] as $colorType) {
             $value = (array) ($this->properties['colors'][$colorType] ?? []);
@@ -553,6 +555,16 @@ final class Styles
     {
         return $this->with(['styles' => [
             'justifyBetween' => true,
+        ]]);
+    }
+
+    /**
+     * Justifies childs along the element with an equal amount of space around each item.
+     */
+    final public function justifyEvenly(): self
+    {
+        return $this->with(['styles' => [
+            'justifyEvenly' => true,
         ]]);
     }
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -441,3 +441,28 @@ test('justify-evenly with no space available to add', function () {
 
     expect($html)->toBe('ABC');
 });
+
+
+test('justify-around', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-11 justify-around">
+            <span>A</span>
+            <span>B</span>
+            <span>C</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe(' A   B   C ');
+});
+
+test('justify-around with no space available to add', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-3 justify-around">
+            <span>A</span>
+            <span>B</span>
+            <span>C</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('ABC');
+});

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -417,3 +417,15 @@ test('justify-between with no space available to add', function () {
 
     expect($html)->toBe('ABC');
 });
+
+test('justify-evenly', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-11 justify-evenly">
+            <span>A</span>
+            <span>B</span>
+            <span>C</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('  A  B  C  ');
+});

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -442,7 +442,6 @@ test('justify-evenly with no space available to add', function () {
     expect($html)->toBe('ABC');
 });
 
-
 test('justify-around', function () {
     $html = parse(<<<'HTML'
         <div class="w-11 justify-around">

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -429,3 +429,15 @@ test('justify-evenly', function () {
 
     expect($html)->toBe('  A  B  C  ');
 });
+
+test('justify-evenly with no space available to add', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-3 justify-evenly">
+            <span>A</span>
+            <span>B</span>
+            <span>C</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('ABC');
+});


### PR DESCRIPTION
This PR adds the `justify-around` and `justify-evenly` to the classes.

### Example Output:
<img width="1137" alt="image" src="https://user-images.githubusercontent.com/823088/164487820-a72f45d6-bc8f-4121-9e73-3d0c0310fcb6.png">

