### PR TITLE
feat: Add `flex` and `flex-1` classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ All the classes supported use exactly the same logic that is available on [tailw
 * **[Max Width](https://tailwindcss.com/docs/max-width):** `max-w-{width}`
 * **[Justify Content](https://tailwindcss.com/docs/justify-content):** `justify-between`, `justify-around`, `justify-evenly`, `justify-center`
 * **[Visibility](https://tailwindcss.com/docs/visibility):** `invisible`
-* **[Display](https://tailwindcss.com/docs/display):** `block`, `hidden`
+* **[Display](https://tailwindcss.com/docs/display):** `block`, `flex`, `hidden`
+* **[Flex](https://tailwindcss.com/docs/flex):** `flex-1`
 * **[List Style](https://tailwindcss.com/docs/list-style-type):** `list-disc`, `list-decimal`, `list-square`, `list-none`
 
 ## Responsive Design

--- a/src/Components/Element.php
+++ b/src/Components/Element.php
@@ -19,6 +19,7 @@ use Termwind\ValueObjects\Styles;
  * @method Element underline()
  * @method Element lineThrough()
  * @method int getLength()
+ * @method int getInnerWidth()
  * @method array getProperties()
  * @method Element href(string $href)
  * @method bool hasStyle(string $style)

--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -31,6 +31,12 @@ final class InheritStyles
             $element->inheritFromStyles($styles);
         }
 
+        /** @var Element[] $elements */
+
+        if (($styles->getProperties()['styles']['display'] ?? 'inline') === 'flex') {
+            $elements = $this->applyFlex($elements);
+        }
+
         return match ($styles->getProperties()['styles']['justifyContent'] ?? false) {
             'between' => $this->applyJustifyBetween($elements),
             'evenly' => $this->applyJustifyEvenly($elements),
@@ -41,9 +47,41 @@ final class InheritStyles
     }
 
     /**
+     * Applies flex-1 to child elements with the class.
+     *
+     * @param  array<int, Element>  $elements
+     * @return array<int, Element>
+     */
+    private function applyFlex(array $elements): array
+    {
+        [$totalWidth, $parentWidth] = $this->getWidthFromElements($elements);
+
+        $width = $parentWidth - $totalWidth + array_reduce($elements, fn ($carry, $element) =>
+            $carry += $element->hasStyle('flex-1') ? $element->getInnerWidth() : 0
+        , 0);
+
+        $flexed = array_values(array_filter(
+            $elements, fn ($element) => $element->hasStyle('flex-1')
+        ));
+
+        foreach ($flexed as $index => &$element) {
+            $float = $width / count($flexed);
+            $elementWidth = floor($float);
+
+            if ($index === count($flexed) - 1) {
+                $elementWidth += ($float - floor($float)) * count($flexed);
+            }
+
+            $element->addStyle("w-{$elementWidth}");
+        }
+
+        return $elements;
+    }
+
+    /**
      * Applies the space between the elements.
      *
-     * @param  array<int, Element|string>  $elements
+     * @param  array<int, Element>  $elements
      * @return array<int, Element|string>
      */
     private function applyJustifyBetween(array $elements): array
@@ -73,7 +111,7 @@ final class InheritStyles
     /**
      * Applies the space between and around the elements.
      *
-     * @param  array<int, Element|string>  $elements
+     * @param  array<int, Element>  $elements
      * @return array<int, Element|string>
      */
     private function applyJustifyEvenly(array $elements): array
@@ -100,7 +138,7 @@ final class InheritStyles
     /**
      * Applies the space around the elements.
      *
-     * @param  array<int, Element|string>  $elements
+     * @param  array<int, Element>  $elements
      * @return array<int, Element|string>
      */
     private function applyJustifyAround(array $elements): array
@@ -134,7 +172,7 @@ final class InheritStyles
     /**
      * Applies the space on before first element and after last element.
      *
-     * @param  array<int, Element|string>  $elements
+     * @param  array<int, Element>  $elements
      * @return array<int, Element|string>
      */
     private function applyJustifyCenter(array $elements): array
@@ -156,12 +194,11 @@ final class InheritStyles
     /**
      * Gets the total width for the elements and their parent width.
      *
-     * @param  array<int, Element|string>  $elements
+     * @param  array<int, Element>  $elements
      * @return int[]
      */
     private function getWidthFromElements(array $elements)
     {
-        /** @var Element[] $elements */
         $totalWidth = (int) array_reduce($elements, fn ($carry, $element) => $carry += $element->getLength(), 0);
         $parentWidth = Styles::getParentWidth($elements[0]->getProperties()['parentStyles'] ?? []);
 

--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -32,7 +32,6 @@ final class InheritStyles
         }
 
         /** @var Element[] $elements */
-
         if (($styles->getProperties()['styles']['display'] ?? 'inline') === 'flex') {
             $elements = $this->applyFlex($elements);
         }

--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -56,9 +56,9 @@ final class InheritStyles
     {
         [$totalWidth, $parentWidth] = $this->getWidthFromElements($elements);
 
-        $width = $parentWidth - $totalWidth + array_reduce($elements, fn ($carry, $element) =>
-            $carry += $element->hasStyle('flex-1') ? $element->getInnerWidth() : 0
-        , 0);
+        $width = array_reduce($elements, function ($carry, $element) {
+            return $carry += $element->hasStyle('flex-1') ? $element->getInnerWidth() : 0;
+        }, $parentWidth - $totalWidth);
 
         $flexed = array_values(array_filter(
             $elements, fn ($element) => $element->hasStyle('flex-1')

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -538,6 +538,26 @@ final class Styles
     }
 
     /**
+     * Makes an element eligible to work with flex-1 element's style.
+     */
+    final public function flex(): self
+    {
+        return $this->with(['styles' => [
+            'display' => 'flex',
+        ]]);
+    }
+
+    /**
+     * Makes an element grow and shrink as needed, ignoring the initial size.
+     */
+    final public function flex1(): self
+    {
+        return $this->with(['styles' => [
+            'flex-1' => true,
+        ]]);
+    }
+
+    /**
      * Justifies childs along the element with an equal amount of space between.
      */
     final public function justifyBetween(): self
@@ -834,7 +854,7 @@ final class Styles
 
         $items = [];
 
-        if ($display === 'block' && ! $isFirstChild) {
+        if (in_array($display, ['block', 'flex'], true) && ! $isFirstChild) {
             $items[] = "\n";
         }
 
@@ -869,6 +889,17 @@ final class Styles
             '',
             $text ?? $this->element?->toString() ?? ''
         ) ?? '', 'UTF-8');
+    }
+
+    /**
+     * Get the length of the element without margins.
+     */
+    public function getInnerWidth(): int
+    {
+        $innerLength = $this->getLength();
+        [, $marginRight, , $marginLeft] = $this->getMargins();
+
+        return $innerLength - $marginLeft - $marginRight;
     }
 
     /**

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -506,6 +506,17 @@ test('justify-centr with no space available to add', function () {
     expect($html)->toBe('ABC');
 });
 
+test('flex', function () {
+    $html = parse(<<<'HTML'
+        <div>
+            <div class="flex">Hello</div>
+            <div class="flex">World</div>
+        </div>
+    HTML);
+
+    expect($html)->toBe("Hello\nWorld");
+});
+
 test('flex and flex-1', function () {
     $html = parse(<<<'HTML'
         <div class="flex w-10">

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -506,6 +506,31 @@ test('justify-centr with no space available to add', function () {
     expect($html)->toBe('ABC');
 });
 
+test('flex and flex-1', function () {
+    $html = parse(<<<'HTML'
+        <div class="flex w-10">
+            <span>A</span>
+            <span class="flex-1"></span>
+            <span>B</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('A        B');
+});
+
+test('flex with multiple flex-1', function () {
+    $html = parse(<<<'HTML'
+        <div class="flex w-11">
+            <span class="flex-1"></span>
+            <span>-</span>
+            <span class="flex-1"></span>
+            <span>-</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('    -     -');
+});
+
 test('hidden', function () {
     $html = parse(<<<'HTML'
         <div class="hidden">test</div>


### PR DESCRIPTION
This PR adds the capability to have a class `flex-1` that will make the element grow and shrink as needed, ignoring the initial size.

The `flex` class works the same way  of the `block`, but will allow a direct child with the `flex-1` class to work.

### Example:

```php
render(<<<'HTML'
    <div class="flex mx-2 my-1">
        <span>First</span>
        <span class="flex-1"></span>
        <span>Last</span>
    </div>
HTML);
```

### Output:
<img width="983" alt="Screen Shot 2022-05-04 at 22 23 29" src="https://user-images.githubusercontent.com/823088/166828130-7ba05827-e2c7-4b07-a459-41f64eea8562.png">

Will be useful for stuff like this:

<img width="943" alt="image" src="https://user-images.githubusercontent.com/823088/166828180-b8cb20c8-8700-4d0a-9889-9b16b349a011.png">


Thanks.