### PR TITLE
Add `.content-repeat` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ All the classes supported use exactly the same logic that is available on [tailw
 * **[Display](https://tailwindcss.com/docs/display):** `block`, `flex`, `hidden`
 * **[Flex](https://tailwindcss.com/docs/flex):** `flex-1`
 * **[List Style](https://tailwindcss.com/docs/list-style-type):** `list-disc`, `list-decimal`, `list-square`, `list-none`
+* **[Content](https://tailwindcss.com/docs/content):** `content-repeat-['.']`
 
 ## Responsive Design
 

--- a/playground.php
+++ b/playground.php
@@ -5,34 +5,18 @@ require_once __DIR__.'/vendor/autoload.php';
 use function Termwind\render;
 
 render(<<<'HTML'
-    <div class="mx-2 my-1">
-        <div class="space-y-1">
-            <div class="justify-evenly space-x-2 bg-blue-300">
-                <span class="px-1 bg-blue-500">A</span>
-                <span class="px-1 bg-blue-500">B</span>
-                <span class="px-1 bg-blue-500">C</span>
-                <span class="px-1 bg-blue-500">C</span>
-                <span class="px-1 bg-blue-500">C</span>
-                <span class="px-1 bg-blue-500">C</span>
-                <span class="px-1 bg-blue-500">C</span>
+    <div class="mx-2 my-1 space-y-1">
+        <div class="px-2 font-bold text-black bg-purple-500">Working on some new features for 🍃 Termwind!</div>
+        <div>
+            <div class="flex space-x-1">
+                <span>Add <b><i>.flex</i></b> and <b><i>.flex-1</i></b> support</span>
+                <span class="flex-1 text-gray content-repeat-['.']"></span>
+                <span class="text-green">✓ Done</span>
             </div>
-            <div class="justify-between space-x-2 bg-pink-300">
-                <span class="px-1 bg-pink-500">A</span>
-                <span class="px-1 bg-pink-500">B</span>
-                <span class="px-1 bg-pink-500">C</span>
-            </div>
-            <div class="justify-around space-x-2 bg-purple-300">
-                <span class="px-1 bg-purple-500">A</span>
-                <span class="px-1 bg-purple-500">B</span>
-                <span class="px-1 bg-purple-500">C</span>
-            </div>
-            <div class="justify-center space-x-2 bg-red-300">
-                <span class="px-1 bg-red-500">A</span>
-                <span class="px-1 bg-red-500">B</span>
-                <span class="px-1 bg-red-500">C</span>
-                <span class="px-1 bg-red-500">C</span>
-                <span class="px-1 bg-red-500">C</span>
-                <span class="px-1 bg-red-500">C</span>
+            <div class="flex space-x-1">
+                <span>Add <b><i>.content-repeat-['-.']</i></b> support</span>
+                <span class="flex-1 text-gray content-repeat-['-.']"></span>
+                <span class="text-green">✓ Done</span>
             </div>
         </div>
     </div>

--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -45,7 +45,7 @@ final class StyleToMethod
      */
     public static function multiple(Styles $styles, string $stylesString): Styles
     {
-        $stylesString = array_merge($styles->defaultStyles(), self::parseStyles($stylesString));
+        $stylesString = array_merge($styles->defaultStyles(), preg_split('/(?![^\[]*\])\s/', $stylesString));
         $stylesString = self::sortStyles($stylesString);
 
         foreach ($stylesString as $style) {
@@ -72,7 +72,8 @@ final class StyleToMethod
             return $this->styles;
         }
 
-        $method = $this->parseMethod($method, $arguments);
+        $method = preg_split('/(?![^\[]*\])-/', $method);
+        $method = array_slice($method, 0, count($method) - count($arguments));
 
         $methodName = implode(' ', $method);
         $methodName = ucwords($methodName);
@@ -122,69 +123,6 @@ final class StyleToMethod
         });
 
         return $styles;
-    }
-
-    /**
-     * Parses the full list of styles into an array with all the methods.
-     *
-     * @return string[]
-     */
-    private static function parseStyles(string $str): array
-    {
-        $str = trim($str);
-        $length = mb_strlen($str, 'UTF-8');
-
-        $classes = [];
-        $start = 0;
-        $inBrackets = false;
-
-        for ($i = 0; $i < $length; $i++) {
-            if ($str[$i] === '[') {
-                $inBrackets = true;
-            } elseif ($str[$i] === ']') {
-                $inBrackets = false;
-            }
-
-            if ((preg_match('/\s/', $str[$i]) === 1 || $i === $length - 1)
-                && ! $inBrackets) {
-                $classes[] = trim(substr($str, $start, ($i + 1) - $start));
-                $start = $i;
-            }
-        }
-
-        return $classes;
-    }
-
-    /**
-     * Parses the full method name into an array of arguments.
-     *
-     * @param  array<int|string, string|int>  $arguments
-     * @return string[]
-     */
-    private function parseMethod(string $method, array $arguments): array
-    {
-        $length = mb_strlen($method, 'UTF-8');
-
-        $start = 0;
-        $inBrackets = false;
-        $items = [];
-
-        for ($i = 0; $i < $length; $i++) {
-            if ($method[$i] === '[') {
-                $inBrackets = true;
-            } elseif ($method[$i] === ']') {
-                $inBrackets = false;
-            }
-
-            $isLastChar = $i === $length - 1;
-
-            if (($method[$i] === '-' || $isLastChar) && ! $inBrackets) {
-                $items[] = trim(substr($method, $start, ($i + ($isLastChar ? 1 : 0)) - $start));
-                $start = $i + 1;
-            }
-        }
-
-        return array_slice($items, 0, count($items) - count($arguments));
     }
 
     /**

--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -141,7 +141,7 @@ final class StyleToMethod
         for ($i = 0; $i < $length; $i++) {
             if ($str[$i] === '[') {
                 $inBrackets = true;
-            } else if ($str[$i] === ']') {
+            } elseif ($str[$i] === ']') {
                 $inBrackets = false;
             }
 
@@ -172,13 +172,13 @@ final class StyleToMethod
         for ($i = 0; $i < $length; $i++) {
             if ($method[$i] === '[') {
                 $inBrackets = true;
-            } else if ($method[$i] === ']') {
+            } elseif ($method[$i] === ']') {
                 $inBrackets = false;
             }
 
             $isLastChar = $i === $length - 1;
 
-            if (($method[$i] === '-' || $isLastChar) && ! $inBrackets)  {
+            if (($method[$i] === '-' || $isLastChar) && ! $inBrackets) {
                 $items[] = trim(substr($method, $start, ($i + ($isLastChar ? 1 : 0)) - $start));
                 $start = $i + 1;
             }

--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -45,12 +45,7 @@ final class StyleToMethod
      */
     public static function multiple(Styles $styles, string $stylesString): Styles
     {
-        $stylesString = array_merge($styles->defaultStyles(), explode(' ', $stylesString));
-
-        $stylesString = array_filter($stylesString, static function ($style): bool {
-            return $style !== '';
-        });
-
+        $stylesString = array_merge($styles->defaultStyles(), self::parseStyles($stylesString));
         $stylesString = self::sortStyles($stylesString);
 
         foreach ($stylesString as $style) {
@@ -77,8 +72,7 @@ final class StyleToMethod
             return $this->styles;
         }
 
-        $method = explode('-', $method);
-        $method = array_slice($method, 0, count($method) - count($arguments));
+        $method = $this->parseMethod($method, $arguments);
 
         $methodName = implode(' ', $method);
         $methodName = ucwords($methodName);
@@ -128,6 +122,69 @@ final class StyleToMethod
         });
 
         return $styles;
+    }
+
+    /**
+     * Parses the full list of styles into an array with all the methods.
+     *
+     * @return string[]
+     */
+    private static function parseStyles(string $str): array
+    {
+        $str = trim($str);
+        $length = mb_strlen($str, 'UTF-8');
+
+        $classes = [];
+        $start = 0;
+        $inBrackets = false;
+
+        for ($i = 0; $i < $length; $i++) {
+            if ($str[$i] === '[') {
+                $inBrackets = true;
+            } else if ($str[$i] === ']') {
+                $inBrackets = false;
+            }
+
+            if ((preg_match('/\s/', $str[$i]) === 1 || $i === $length - 1)
+                && ! $inBrackets) {
+                $classes[] = trim(substr($str, $start, ($i + 1) - $start));
+                $start = $i;
+            }
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Parses the full method name into an array of arguments.
+     *
+     * @param  array<int|string, string|int>  $arguments
+     * @return string[]
+     */
+    private function parseMethod(string $method, array $arguments): array
+    {
+        $length = mb_strlen($method, 'UTF-8');
+
+        $start = 0;
+        $inBrackets = false;
+        $items = [];
+
+        for ($i = 0; $i < $length; $i++) {
+            if ($method[$i] === '[') {
+                $inBrackets = true;
+            } else if ($method[$i] === ']') {
+                $inBrackets = false;
+            }
+
+            $isLastChar = $i === $length - 1;
+
+            if (($method[$i] === '-' || $isLastChar) && ! $inBrackets)  {
+                $items[] = trim(substr($method, $start, ($i + ($isLastChar ? 1 : 0)) - $start));
+                $start = $i + 1;
+            }
+        }
+
+        return array_slice($items, 0, count($items) - count($arguments));
     }
 
     /**

--- a/src/Actions/StyleToMethod.php
+++ b/src/Actions/StyleToMethod.php
@@ -45,8 +45,10 @@ final class StyleToMethod
      */
     public static function multiple(Styles $styles, string $stylesString): Styles
     {
-        $stylesString = array_merge($styles->defaultStyles(), preg_split('/(?![^\[]*\])\s/', $stylesString));
-        $stylesString = self::sortStyles($stylesString);
+        $stylesString = self::sortStyles(array_merge(
+            $styles->defaultStyles(),
+            array_filter((array) preg_split('/(?![^\[]*\])\s/', $stylesString))
+        ));
 
         foreach ($stylesString as $style) {
             $styles = (new self($styles, $style))->__invoke();
@@ -72,7 +74,7 @@ final class StyleToMethod
             return $this->styles;
         }
 
-        $method = preg_split('/(?![^\[]*\])-/', $method);
+        $method = array_filter((array) preg_split('/(?![^\[]*\])-/', $method));
         $method = array_slice($method, 0, count($method) - count($arguments));
 
         $methodName = implode(' ', $method);

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -598,11 +598,14 @@ final class Styles
         ]]);
     }
 
+    /**
+     * Repeats the string given until it fills all the content.
+     */
     final public function contentRepeat(string $string): self
     {
-        $string = preg_replace("/\[?'?([^'|\]]+)'?\]?/", '$1', $string);
+        $string = preg_replace("/\[?'?([^'|\]]+)'?\]?/", '$1', $string) ?? '';
 
-        $this->textModifiers[__METHOD__] = static fn (): string => str_repeat($string, terminal()->width());
+        $this->textModifiers[__METHOD__] = static fn (): string => str_repeat($string, (int) floor(terminal()->width() / mb_strlen($string, 'UTF-8')));
 
         return $this;
     }

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -598,6 +598,15 @@ final class Styles
         ]]);
     }
 
+    final public function contentRepeat(string $string): self
+    {
+        $string = preg_replace("/\[?'?([^'|\]]+)'?\]?/", '$1', $string);
+
+        $this->textModifiers[__METHOD__] = static fn (): string => str_repeat($string, terminal()->width());
+
+        return $this;
+    }
+
     /**
      * Prepends text to the content.
      */

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -557,5 +557,3 @@ test('content-repeat', function () {
 
     expect($html)->toBe(str_repeat('. -', 3));
 });
-
-

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -549,3 +549,13 @@ test('hidden', function () {
 
     expect($html)->toBe('');
 });
+
+test('content-repeat', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-9 content-repeat-['. -']"></div>
+    HTML);
+
+    expect($html)->toBe(str_repeat('. -', 3));
+});
+
+


### PR DESCRIPTION
This PR adds the capability to have a way to do a pattern repeat like this:

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/823088/167886201-1307ca89-a12d-4cb9-b2bd-d3eb2541dd7c.png">

This is the first class not available on `TailwindCSS`, but is really helpful for CLI outputs.