### PR TITLE
feat: Allow `truncate` to be used without params.

### DIFF
--- a/playground.php
+++ b/playground.php
@@ -5,19 +5,10 @@ require_once __DIR__.'/vendor/autoload.php';
 use function Termwind\render;
 
 render(<<<'HTML'
-    <div class="mx-2 my-1 space-y-1">
-        <div class="px-2 font-bold text-black bg-purple-500">Working on some new features for 🍃 Termwind!</div>
-        <div>
-            <div class="flex space-x-1">
-                <span>Add <b><i>.flex</i></b> and <b><i>.flex-1</i></b> support</span>
-                <span class="flex-1 text-gray content-repeat-['.']"></span>
-                <span class="text-green">✓ Done</span>
-            </div>
-            <div class="flex space-x-1">
-                <span>Add <b><i>.content-repeat-['-.']</i></b> support</span>
-                <span class="flex-1 text-gray content-repeat-['-.']"></span>
-                <span class="text-green">✓ Done</span>
-            </div>
+    <div class="mx-2 my-1">
+        <div class="flex space-x-1">
+            <span class="flex-1 truncate">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sunt illo et nisi omnis porro at, mollitia harum quas esse, aperiam dolorem ab recusandae fugiat nesciunt doloribus rem eaque nostrum itaque.</span>
+            <span class="text-green">DONE</span>
         </div>
     </div>
 HTML);

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -411,9 +411,14 @@ final class Styles
     /**
      * Truncates the text of the element.
      */
-    final public function truncate(int $limit, string $end = '...'): self
+    final public function truncate(int $limit = 0, string $end = '…'): self
     {
-        $this->textModifiers[__METHOD__] = static function ($text) use ($limit, $end): string {
+        $this->textModifiers[__METHOD__] = static function ($text, $styles) use ($limit, $end): string {
+            $limit = $limit > 0 ? $limit : ($styles['width'] ?? 0);
+            if ($limit === 0) {
+                return $text;
+            }
+
             $limit -= mb_strwidth($end, 'UTF-8');
 
             if (mb_strwidth($text, 'UTF-8') <= $limit) {

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -139,7 +139,23 @@ test('truncate', function () {
         </span>
     HTML);
 
-    expect($html)->toBe('te...text text');
+    expect($html)->toBe('text…text text');
+});
+
+test('truncate without params', function () {
+    $html = parse(<<<'HTML'
+        <span class="truncate w-5">truncate</span>
+    HTML);
+
+    expect($html)->toBe('trun…');
+});
+
+test('truncate without params and width', function () {
+    $html = parse(<<<'HTML'
+        <span class="truncate">text</span>
+    HTML);
+
+    expect($html)->toBe('text');
 });
 
 test('w', function () {


### PR DESCRIPTION
This PR adds the capability to use the `truncate` class to be used without params.

If it's used without params, it will look for the `width` on the elem.

```php
render(<<<'HTML'
    <div class="mx-2 my-1">
        <div class="flex space-x-1">
            <span class="flex-1 truncate">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sunt illo et nisi omnis porro at, mollitia harum quas esse, aperiam dolorem ab recusandae fugiat nesciunt doloribus rem eaque nostrum itaque.</span>
            <span class="text-green">DONE</span>
        </div>
    </div>
HTML);
```

### Output

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/823088/174291506-aa5fdadc-ab7a-4ccf-9c82-01cfb0d6612d.png">
