### PR TITLE
fix: `flex-1` with over `COLUMN` size content.

### DIFF
--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -55,15 +55,19 @@ final class InheritStyles
     {
         [$totalWidth, $parentWidth] = $this->getWidthFromElements($elements);
 
-        $width = array_reduce($elements, function ($carry, $element) {
+        $width = max(0, array_reduce($elements, function ($carry, $element) {
             return $carry += $element->hasStyle('flex-1') ? $element->getInnerWidth() : 0;
-        }, $parentWidth - $totalWidth);
+        }, $parentWidth - $totalWidth));
 
         $flexed = array_values(array_filter(
             $elements, fn ($element) => $element->hasStyle('flex-1')
         ));
 
         foreach ($flexed as $index => &$element) {
+            if ($width === 0 && ! ($element->getProperties()['styles']['contentRepeat'] ?? false)) {
+                continue;
+            }
+
             $float = $width / count($flexed);
             $elementWidth = floor($float);
 

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -613,7 +613,9 @@ final class Styles
 
         $this->textModifiers[__METHOD__] = static fn (): string => str_repeat($string, (int) floor(terminal()->width() / mb_strlen($string, 'UTF-8')));
 
-        return $this;
+        return $this->with(['styles' => [
+            'contentRepeat' => true,
+        ]]);
     }
 
     /**

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -574,6 +574,34 @@ test('flex with multiple flex-1', function () {
     expect($html)->toBe('    -     -');
 });
 
+test('flex, flex-1 and content above column size', function () {
+    putenv('COLUMNS=10');
+
+    $html = parse(<<<'HTML'
+        <div class="flex">
+            <span>a</span>
+            <span class="flex-1">-</span>
+            <span>over column size</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('a-over column size');
+});
+
+test('flex, flex-1 with content-repeat and content above column size', function () {
+    putenv('COLUMNS=10');
+
+    $html = parse(<<<'HTML'
+        <div class="flex">
+            <span>a</span>
+            <span class="flex-1 content-repeat-[.]"></span>
+            <span>over column size</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('aover column size');
+});
+
 test('hidden', function () {
     $html = parse(<<<'HTML'
         <div class="hidden">test</div>


### PR DESCRIPTION
This PR fixes an issue when using `flex-1` with siblings with over `COLUMN` size.

```php
render(<<<'HTML'
    <div class="flex mx-2">
        <span>
            Issue?
        </span>
        <span class="flex-1 content-repeat-[.] text-gray mx-1"></span>
        <span>
            The goal of this package is to have the closest experience that is available with the Laravel Localization but for the frontend side. The goal of this package is to have the closest experience that is available with the Laravel Localization but for the frontend side.
        </span>
    </div>
HTML);
```

## Before

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/823088/176907745-5b8cba16-37d5-4ced-9e98-afdf66b975ff.png">


## After

<img width="1394" alt="image" src="https://user-images.githubusercontent.com/823088/176907598-b4fa1285-96c6-4ca9-b091-6d629a08337d.png">
