### PR TITLE
feat: Add `min-w-{width}` class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ All the classes supported use exactly the same logic that is available on [tailw
 * **[Padding](https://tailwindcss.com/docs/padding):** `p-{padding}`, `pl-{leftPadding}`, `pr-{rightPadding}`, `pt-{topPadding}`, `pb-{bottomPadding}`, `px-{horizontalPadding}`, `py-{verticalPadding}`.
 * **[Space](https://tailwindcss.com/docs/space):** `space-y-{space}`, `space-x-{space}`.
 * **[Width](https://tailwindcss.com/docs/width):** `w-{width}`, `w-full`
+* **[Min Width](https://tailwindcss.com/docs/min-width):** `min-w-{width}`
 * **[Max Width](https://tailwindcss.com/docs/max-width):** `max-w-{width}`
 * **[Justify Content](https://tailwindcss.com/docs/justify-content):** `justify-between`, `justify-around`, `justify-evenly`, `justify-center`
 * **[Visibility](https://tailwindcss.com/docs/visibility):** `invisible`

--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -55,15 +55,19 @@ final class InheritStyles
     {
         [$totalWidth, $parentWidth] = $this->getWidthFromElements($elements);
 
-        $width = array_reduce($elements, function ($carry, $element) {
+        $width = max(0, array_reduce($elements, function ($carry, $element) {
             return $carry += $element->hasStyle('flex-1') ? $element->getInnerWidth() : 0;
-        }, $parentWidth - $totalWidth);
+        }, $parentWidth - $totalWidth));
 
         $flexed = array_values(array_filter(
             $elements, fn ($element) => $element->hasStyle('flex-1')
         ));
 
         foreach ($flexed as $index => &$element) {
+            if ($width === 0 && ! ($element->getProperties()['styles']['contentRepeat'] ?? false)) {
+                continue;
+            }
+
             $float = $width / count($flexed);
             $elementWidth = floor($float);
 

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -126,7 +126,7 @@ final class Styles
      */
     final public function inheritFromStyles(self $styles): self
     {
-        foreach (['ml', 'mr', 'pl', 'pr', 'width', 'maxWidth', 'spaceY', 'spaceX'] as $style) {
+        foreach (['ml', 'mr', 'pl', 'pr', 'width', 'minWidth', 'maxWidth', 'spaceY', 'spaceX'] as $style) {
             $this->properties['parentStyles'][$style] = array_merge(
                 $this->properties['parentStyles'][$style] ?? [],
                 $styles->properties['parentStyles'][$style] ?? []
@@ -448,6 +448,16 @@ final class Styles
     final public function wFull(): static
     {
         return $this->w('1/1');
+    }
+
+    /**
+     * Defines a minimum width of an element.
+     */
+    final public function minW(int|string $width): static
+    {
+        return $this->with(['styles' => [
+            'minWidth' => $width,
+        ]]);
     }
 
     /**
@@ -792,7 +802,8 @@ final class Styles
     private function applyWidth(string $content): string
     {
         $styles = $this->properties['styles'] ?? [];
-        $width = $styles['width'] ?? -1;
+        $minWidth = $styles['minWidth'] ?? -1;
+        $width = max($styles['width'] ?? -1, $minWidth);
         $maxWidth = $styles['maxWidth'] ?? 0;
 
         if ($width < 0) {
@@ -979,8 +990,11 @@ final class Styles
     {
         $width = terminal()->width();
         foreach ($styles['width'] ?? [] as $index => $parentWidth) {
+            $minWidth = (int) $styles['minWidth'][$index] ?? -1;
             $maxWidth = (int) $styles['maxWidth'][$index];
             $margins = (int) $styles['ml'][$index] + (int) $styles['mr'][$index];
+
+            $parentWidth = max($parentWidth, $minWidth);
 
             if ($parentWidth < 1) {
                 $parentWidth = $width;

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -990,7 +990,7 @@ final class Styles
     {
         $width = terminal()->width();
         foreach ($styles['width'] ?? [] as $index => $parentWidth) {
-            $minWidth = (int) $styles['minWidth'][$index] ?? -1;
+            $minWidth = (int) $styles['minWidth'][$index];
             $maxWidth = (int) $styles['maxWidth'][$index];
             $margins = (int) $styles['ml'][$index] + (int) $styles['mr'][$index];
 

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -613,7 +613,9 @@ final class Styles
 
         $this->textModifiers[__METHOD__] = static fn (): string => str_repeat($string, (int) floor(terminal()->width() / mb_strlen($string, 'UTF-8')));
 
-        return $this;
+        return $this->with(['styles' => [
+            'contentRepeat' => true,
+        ]]);
     }
 
     /**

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -205,6 +205,19 @@ test('invalid w-division', function () {
         ->toThrow(InvalidStyle::class);
 });
 
+test('min-w', function () {
+    putenv('COLUMNS=10');
+
+    $html = parse(<<<'HTML'
+        <div class="flex">
+            <span class="flex-1 content-repeat-[.] min-w-1"></span>
+            <span>Over size content</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('.Over size content');
+});
+
 test('max-w', function () {
     putenv('COLUMNS=10');
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -574,6 +574,34 @@ test('flex with multiple flex-1', function () {
     expect($html)->toBe('    -     -');
 });
 
+test('flex, flex-1 and content above column size', function () {
+    putenv('COLUMNS=10');
+
+    $html = parse(<<<'HTML'
+        <div class="flex">
+            <span>a</span>
+            <span class="flex-1">-</span>
+            <span>over column size</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('a-over column size');
+});
+
+test('flex, flex-1 with content-repeat and content above column size', function () {
+    putenv('COLUMNS=10');
+
+    $html = parse(<<<'HTML'
+        <div class="flex">
+            <span>a</span>
+            <span class="flex-1 content-repeat-[.]"></span>
+            <span>over column size</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('aover column size');
+});
+
 test('hidden', function () {
     $html = parse(<<<'HTML'
         <div class="hidden">test</div>


### PR DESCRIPTION
This PR adds support for the `min-w-{width}` class.

With this addition it will possible to make stuff like this:

```php
render(<<<HTML
    <div class="flex my-1 mx-2 space-x-1">
        <span class="px-1 bg-gray">
            min-w
        </span>
        <span class="flex-1 content-repeat-[.] text-gray min-w-3"></span>
        <span>
            With the `min-w` addition you can make sure that the content repeat always repeat even if there is no space on the line.
        </span>
    </div>
HTML);
```

## Result

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/823088/176913364-a9e5d080-72c9-4b3a-bba1-a5582cb0c8a8.png">
