### PR TITLE
Remove 'orange' color

### DIFF
--- a/src/Enums/Color.php
+++ b/src/Enums/Color.php
@@ -134,8 +134,6 @@ final class Color
 
     public const RED_900 = '#7f1d1d';
 
-    public const ORANGE = 'orange';
-
     public const ORANGE_50 = '#fff7ed';
 
     public const ORANGE_100 = '#ffedd5';


### PR DESCRIPTION
If you use try to use a color that doesn't exist, Termwind throws `ColorNotFound`:

```php
render('<div class="text-fakecolor">Hello World</div>')
/* PHP Fatal error:  Uncaught Termwind\Exceptions\ColorNotFound: FAKECOLOR */
```

However orange is available as a color in Termwind, even though it's not [supported by Symfony](https://symfony.com/doc/current/console/coloring.html#using-color-styles). This causes a different error:

```php
render('<div class="text-orange">Hello World</div>');
/* PHP Fatal error: Uncaught Symfony\Component\Console\Exception\InvalidArgumentException:
 *     Invalid "orange" color; expected one of (black, red, green, yellow, blue, magenta, cyan,
 *     white, default, gray, bright-red, bright-green, bright-yellow, bright-blue, bright-magenta,
 *     bright-cyan, bright-white). in /vendor/symfony/console/Color.php:141 */
```