### PR TITLE
Add full ANSI color support

### DIFF
--- a/src/Enums/Color.php
+++ b/src/Enums/Color.php
@@ -10,6 +10,8 @@ final class Color
 
     public const WHITE = 'white';
 
+    public const BRIGHTWHITE = 'bright-white';
+
     public const SLATE_50 = '#f8fafc';
 
     public const SLATE_100 = '#f1f5f9';
@@ -114,6 +116,8 @@ final class Color
 
     public const RED = 'red';
 
+    public const BRIGHTRED = 'bright-red';
+
     public const RED_50 = '#fef2f2';
 
     public const RED_100 = '#fee2e2';
@@ -178,6 +182,8 @@ final class Color
 
     public const YELLOW = 'yellow';
 
+    public const BRIGHTYELLOW = 'bright-yellow';
+
     public const YELLOW_50 = '#fefce8';
 
     public const YELLOW_100 = '#fef9c3';
@@ -219,6 +225,8 @@ final class Color
     public const LIME_900 = '#365314';
 
     public const GREEN = 'green';
+
+    public const BRIGHTGREEN = 'bright-green';
 
     public const GREEN_50 = '#f0fdf4';
 
@@ -282,6 +290,8 @@ final class Color
 
     public const CYAN = 'cyan';
 
+    public const BRIGHTCYAN = 'bright-cyan';
+
     public const CYAN_50 = '#ecfeff';
 
     public const CYAN_100 = '#cffafe';
@@ -323,6 +333,8 @@ final class Color
     public const SKY_900 = '#0c4a6e';
 
     public const BLUE = 'blue';
+
+    public const BRIGHTBLUE = 'bright-blue';
 
     public const BLUE_50 = '#eff6ff';
 
@@ -465,4 +477,6 @@ final class Color
     public const ROSE_900 = '#881337';
 
     public const MAGENTA = 'magenta';
+
+    public const BRIGHTMAGENTA = 'bright-magenta';
 }

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -25,7 +25,7 @@ final class Styles
     /**
      * Finds all the styling on a string.
      */
-    public const STYLING_REGEX = "/\<[\w=#\/\;,:.&,%?]+\>|\\e\[\d+m/";
+    public const STYLING_REGEX = "/\<[\w=#\/\;,:.&,%?-]+\>|\\e\[\d+m/";
 
     /** @var array<int, string> */
     private array $styles = [];

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -107,6 +107,12 @@ test('bg', function () {
     expect($html)->toBe('<bg=red>text</>');
 });
 
+test('bg-bright', function () {
+    $html = parse('<div class="bg-brightred">text</div>');
+
+    expect($html)->toBe('<bg=bright-red>text</>');
+});
+
 test('bg-color', function () {
     $html = parse('<div class="bg-red-400">text</div>');
 
@@ -117,6 +123,12 @@ test('text-color', function () {
     $html = parse('<div class="text-red">text</div>');
 
     expect($html)->toBe('<fg=red>text</>');
+});
+
+test('text-color-bright', function () {
+    $html = parse('<div class="text-brightred">text</div>');
+
+    expect($html)->toBe('<fg=bright-red>text</>');
 });
 
 test('text-right', function () {

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -410,7 +410,7 @@ test('invisible and snakecase', function () {
     expect($html)->toBe("\e[8mtext_text\e[0m");
 });
 
-test('width with styled children, where output includes color with dash', function() {
+test('width with styled children, where output includes color with dash', function () {
     $html = parse(<<<'HTML'
         <div class="w-10">
             <span class="bg-brightgreen">text</span>

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -410,6 +410,16 @@ test('invisible and snakecase', function () {
     expect($html)->toBe("\e[8mtext_text\e[0m");
 });
 
+test('width with styled children, where output includes color with dash', function() {
+    $html = parse(<<<'HTML'
+        <div class="w-10">
+            <span class="bg-brightgreen">text</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('<bg=bright-green>text</>      ');
+});
+
 test('width, bg, text-right', function () {
     $html = parse(<<<'HTML'
         <div class="w-15 text-right">


### PR DESCRIPTION
PR for #141. Allows Termwind to output all 16 standard ANSI colors, so the colors output can match the user's configured terminal theme.

[Symfony Docs](https://symfony.com/doc/current/console/coloring.html#using-color-styles)

![image](https://user-images.githubusercontent.com/1180782/180295925-edcd75c4-7650-459f-988c-bac3ea719013.png)

FYI: I went with the class name format `text-brightwhite` since dashes aren't currently supported in color names (e.g. `text-bright-white`).