### PR TITLE
feat: Add support for `w-auto`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ All the classes supported use exactly the same logic that is available on [tailw
 * **[Margin](https://tailwindcss.com/docs/margin):** `m-{margin}`, `ml-{leftMargin}`, `mr-{rightMargin}`, `mt-{topMargin}`, `mb-{bottomMargin}`, `mx-{horizontalMargin}`, `my-{verticalMargin}`.
 * **[Padding](https://tailwindcss.com/docs/padding):** `p-{padding}`, `pl-{leftPadding}`, `pr-{rightPadding}`, `pt-{topPadding}`, `pb-{bottomPadding}`, `px-{horizontalPadding}`, `py-{verticalPadding}`.
 * **[Space](https://tailwindcss.com/docs/space):** `space-y-{space}`, `space-x-{space}`.
-* **[Width](https://tailwindcss.com/docs/width):** `w-{width}`, `w-full`
+* **[Width](https://tailwindcss.com/docs/width):** `w-{width}`, `w-full`, `w-auto`
 * **[Min Width](https://tailwindcss.com/docs/min-width):** `min-w-{width}`
 * **[Max Width](https://tailwindcss.com/docs/max-width):** `max-w-{width}`
 * **[Justify Content](https://tailwindcss.com/docs/justify-content):** `justify-between`, `justify-around`, `justify-evenly`, `justify-center`

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -451,6 +451,16 @@ final class Styles
     }
 
     /**
+     * Removes the width set on the element.
+     */
+    final public function wAuto(): static
+    {
+        return $this->with(['styles' => [
+            'width' => null,
+        ]]);
+    }
+
+    /**
      * Defines a minimum width of an element.
      */
     final public function minW(int|string $width): static

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -197,6 +197,14 @@ test('w-division', function () {
     expect($html)->toBe('text      text      ');
 });
 
+test('w-auto', function () {
+    $html = parse(<<<'HTML'
+        <span class="w-auto">text</span>
+    HTML);
+
+    expect($html)->toBe('text');
+});
+
 test('invalid w-division', function () {
     expect(fn () => parse('<span class="w-invalid">text</span>'))
         ->toThrow(InvalidStyle::class);

--- a/tests/mediaQueries.php
+++ b/tests/mediaQueries.php
@@ -23,3 +23,13 @@ it('renders based on the size even if the styles are in the wrong order', functi
 
     expect($html)->toBe('<bg=red>Test</>');
 });
+
+it('resets the width when the breakpoint is reached', function () {
+    putenv('COLUMNS=64');
+
+    $html = parse(<<<'HTML'
+        <div class="w-2 sm:w-auto">text</div>
+    HTML);
+
+    expect($html)->toBe('text');
+});


### PR DESCRIPTION
This PR add the `w-auto` class, that just resets the `width` of the element, it is useful when you use the Media Queries.

## Example:

```php
render(<<<'HTML'
    <div class="my-1 mx-2 w-25 sm:w-auto truncate px-1 bg-red text-black">
        When its a sm screen it will have the width set, but with larger sizes it will have no limitation
    </div>
HTML);
```

## Output
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/823088/181595695-9e4b5d48-d171-4953-b216-ce04f5cb324d.png">
