### PR TITLE
Fixes bug when using `truncate` with paddings

### DIFF
--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -415,12 +415,17 @@ final class Styles
     final public function truncate(int $limit = 0, string $end = '…'): self
     {
         $this->textModifiers[__METHOD__] = function ($text, $styles) use ($limit, $end): string {
-            $limit = $limit > 0 ? $limit : ($styles['width'] ?? 0);
+            $width = $styles['width'] ?? 0;
+            [, $paddingRight, , $paddingLeft] = $this->getPaddings();
+            $width -= $paddingRight + $paddingLeft;
+
+            $limit = $limit > 0 ? $limit : $width;
             if ($limit === 0) {
                 return $text;
             }
 
             $limit -= mb_strwidth($end, 'UTF-8');
+
 
             if ($this->getLength($text) <= $limit) {
                 return $text;

--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -426,7 +426,6 @@ final class Styles
 
             $limit -= mb_strwidth($end, 'UTF-8');
 
-
             if ($this->getLength($text) <= $limit) {
                 return $text;
             }

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -178,6 +178,14 @@ test('truncate with styled childs', function () {
     expect($html)->toBe('text with <bg=gray>s</>…');
 });
 
+test('truncate with paddings', function () {
+    $html = parse(<<<'HTML'
+        <span class="truncate w-5 px-1">text</span>
+    HTML);
+
+    expect($html)->toBe(' te… ');
+});
+
 test('w', function () {
     $html = parse(<<<'HTML'
         <span>


### PR DESCRIPTION
This PR fixes a bug when using `truncate` class that was not working when having paddings.

```php
render(<<<HTML
    <span class="truncate w-5 px-1">text</span>
HTML);
```

## Before
<img width="988" alt="image" src="https://user-images.githubusercontent.com/823088/181800186-ac6bbcb4-1f6c-44c7-9636-82ebd2ec40df.png">

## After
<img width="860" alt="image" src="https://user-images.githubusercontent.com/823088/181800105-0daa4af0-061b-4430-8d1e-1c1b63cdde98.png">
