### PR TITLE
fix: Truncate to work well with `w-full` or `w-division`.

### DIFF
--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -416,6 +416,15 @@ final class Styles
     {
         $this->textModifiers[__METHOD__] = function ($text, $styles) use ($limit, $end): string {
             $width = $styles['width'] ?? 0;
+
+            if (is_string($width)) {
+                $width = self::calcWidthFromFraction(
+                    $width,
+                    $styles,
+                    $this->properties['parentStyles'] ?? []
+                );
+            }
+
             [, $paddingRight, , $paddingLeft] = $this->getPaddings();
             $width -= $paddingRight + $paddingLeft;
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -186,6 +186,28 @@ test('truncate with paddings', function () {
     expect($html)->toBe(' te… ');
 });
 
+test('truncate with w-full', function () {
+    putenv('COLUMNS=5');
+
+    $html = parse(<<<'HTML'
+        <span class="w-full truncate">texttext</span>
+    HTML);
+
+    expect($html)->toBe('text…');
+});
+
+test('truncate with w-division', function () {
+    putenv('COLUMNS=6');
+
+    $html = parse(<<<'HTML'
+        <div class="w-full">
+            <span class="w-1/2 truncate">texttext</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('te…   ');
+});
+
 test('w', function () {
     $html = parse(<<<'HTML'
         <span>


### PR DESCRIPTION
This PR adds a bug fix when using truncate with `w-full` or `w-1/2`.

```php
render(<<<HTML
    <div class="mx-2 my-1">
        <div class="w-full truncate">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Sunt illo et nisi omnis porro at, mollitia harum quas esse, aperiam dolorem ab recusandae fugiat nesciunt doloribus rem eaque nostrum itaque.</div>
    </div>
HTML);
```

## Before
<img width="895" alt="image" src="https://user-images.githubusercontent.com/823088/194752359-bb14c932-4328-4807-9dc9-db71734cebd9.png">

## After
<img width="886" alt="image" src="https://user-images.githubusercontent.com/823088/194752331-e2643441-d632-4cc7-baac-fc0fedc97c71.png">