### PR TITLE
Require `ext-xml` as `DOMDocument` is used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": "^8.0",
         "ext-mbstring": "*",
+        "ext-xml": "*",
         "symfony/console": "^5.3.0|^6.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Currently it is possible to install the package without having the extension installed.
But running code using the package results in an exception, because `DOMDocument` is not found.