### PR TITLE
Add support for custom renderers

### DIFF
--- a/src/Contracts/Renderer.php
+++ b/src/Contracts/Renderer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Termwind\Contracts;
+
+use Termwind\Components\Element;
+use Termwind\ValueObjects\Node;
+
+interface Renderer
+{
+    /**
+     * Gets HTML content from a given node and converts to the content element.
+     */
+    public function toElement(Node $node): Element;
+}

--- a/src/Exceptions/InvalidRenderer.php
+++ b/src/Exceptions/InvalidRenderer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Termwind\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * @internal
+ */
+final class InvalidRenderer extends InvalidArgumentException
+{
+}

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -6,6 +6,7 @@ namespace Termwind;
 
 use Closure;
 use Symfony\Component\Console\Output\OutputInterface;
+use Termwind\Html\ElementRenderer;
 use Termwind\Repositories\Styles as StyleRepository;
 use Termwind\ValueObjects\Style;
 use Termwind\ValueObjects\Styles;
@@ -61,5 +62,21 @@ if (! function_exists('Termwind\ask')) {
     function ask(string $question, iterable $autocomplete = null): mixed
     {
         return (new Question)->ask($question, $autocomplete);
+    }
+}
+
+if (! function_exists('Termwind\registerRenderer')) {
+    /**
+     * Registers a new renderer
+     *
+     * @param  string  $name
+     * @param  string  $renderer
+     * @return void
+     *
+     * @thows InvalidRenderer
+     */
+    function registerRenderer(string $name, string $renderer): void
+    {
+        ElementRenderer::register($name, $renderer);
     }
 }

--- a/src/Html/CodeRenderer.php
+++ b/src/Html/CodeRenderer.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Termwind\Html;
 
 use Termwind\Components\Element;
+use Termwind\Contracts\Renderer;
 use Termwind\Termwind;
 use Termwind\ValueObjects\Node;
 
 /**
  * @internal
  */
-final class CodeRenderer
+final class CodeRenderer implements Renderer
 {
     public const TOKEN_DEFAULT = 'token_default';
 

--- a/src/Html/ElementRenderer.php
+++ b/src/Html/ElementRenderer.php
@@ -21,6 +21,14 @@ final class ElementRenderer
     ];
 
     /**
+     * @return array
+     */
+    public static function renderers(): array
+    {
+        return self::$renderers;
+    }
+
+    /**
      * Checks if there is any renderer registered for the node name
      *
      * @param  string  $name
@@ -47,7 +55,7 @@ final class ElementRenderer
             throw new InvalidRenderer();
         }
 
-        self::$renderers[] = [$name => $renderer];
+        self::$renderers[$name] = $renderer;
     }
 
     /**

--- a/src/Html/ElementRenderer.php
+++ b/src/Html/ElementRenderer.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Termwind\Html;
+
+use Termwind\Components\Element;
+use Termwind\Contracts\Renderer;
+use Termwind\Exceptions\InvalidRenderer;
+use Termwind\ValueObjects\Node;
+
+final class ElementRenderer
+{
+    /**
+     * @var array<string, string>
+     */
+    private static array $renderers = [
+        'table' => TableRenderer::class,
+        'code' => CodeRenderer::class,
+        'pre' => PreRenderer::class,
+    ];
+
+    /**
+     * Checks if there is any renderer registered for the node name
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public static function hasRenderer(string $name): bool
+    {
+        return array_key_exists($name, self::$renderers);
+    }
+
+    /**
+     * Registers a new renderer
+     *
+     * @param  string  $name
+     * @param  string  $renderer
+     * @return void
+     *
+     * @thows InvalidRenderer
+     */
+    public static function register(string $name, string $renderer): void
+    {
+        $rendererObject = new $renderer();
+        if (! ($rendererObject instanceof Renderer)) {
+            throw new InvalidRenderer();
+        }
+
+        self::$renderers[] = [$name => $renderer];
+    }
+
+    /**
+     * Renders the given Node
+     *
+     * @param  Node  $node
+     * @return Element
+     *
+     * @thows InvalidRenderer
+     */
+    public static function render(Node $node): Element
+    {
+        $nodeName = $node->getName();
+
+        if (! self::hasRenderer($nodeName)) {
+            throw new InvalidRenderer();
+        }
+
+        /** @var Renderer $renderer */
+        $renderer = (new self::$renderers[$nodeName]);
+
+        return $renderer->toElement($node);
+    }
+}

--- a/src/Html/ElementRenderer.php
+++ b/src/Html/ElementRenderer.php
@@ -12,7 +12,7 @@ use Termwind\ValueObjects\Node;
 final class ElementRenderer
 {
     /**
-     * @var array<string, string>
+     * @var array<string, class-string<Renderer>>
      */
     private static array $renderers = [
         'table' => TableRenderer::class,
@@ -21,7 +21,7 @@ final class ElementRenderer
     ];
 
     /**
-     * @return array<string, string>
+     * @return array<string, class-string<Renderer>>
      */
     public static function renderers(): array
     {
@@ -50,8 +50,7 @@ final class ElementRenderer
      */
     public static function register(string $name, string $renderer): void
     {
-        $rendererObject = new $renderer();
-        if (! ($rendererObject instanceof Renderer)) {
+        if (! is_a($renderer, Renderer::class, true)) {
             throw new InvalidRenderer();
         }
 

--- a/src/Html/ElementRenderer.php
+++ b/src/Html/ElementRenderer.php
@@ -9,6 +9,9 @@ use Termwind\Contracts\Renderer;
 use Termwind\Exceptions\InvalidRenderer;
 use Termwind\ValueObjects\Node;
 
+/**
+ * @interal
+ */
 final class ElementRenderer
 {
     /**

--- a/src/Html/ElementRenderer.php
+++ b/src/Html/ElementRenderer.php
@@ -21,7 +21,7 @@ final class ElementRenderer
     ];
 
     /**
-     * @return array
+     * @return array<string, string>
      */
     public static function renderers(): array
     {

--- a/src/Html/PreRenderer.php
+++ b/src/Html/PreRenderer.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Termwind\Html;
 
 use Termwind\Components\Element;
+use Termwind\Contracts\Renderer;
 use Termwind\Termwind;
 use Termwind\ValueObjects\Node;
 
 /**
  * @internal
  */
-final class PreRenderer
+final class PreRenderer implements Renderer
 {
     /**
      * Gets HTML content from a given node and converts to the content element.

--- a/src/Html/TableRenderer.php
+++ b/src/Html/TableRenderer.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Termwind\Components\Element;
+use Termwind\Contracts\Renderer;
 use Termwind\HtmlRenderer;
 use Termwind\Termwind;
 use Termwind\ValueObjects\Node;
@@ -20,7 +21,7 @@ use Termwind\ValueObjects\Styles;
 /**
  * @internal
  */
-final class TableRenderer
+final class TableRenderer implements Renderer
 {
     /**
      * Symfony table object uses for table generation.

--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -6,9 +6,7 @@ namespace Termwind;
 
 use DOMDocument;
 use DOMNode;
-use Termwind\Html\CodeRenderer;
-use Termwind\Html\PreRenderer;
-use Termwind\Html\TableRenderer;
+use Termwind\Html\ElementRenderer;
 use Termwind\ValueObjects\Node;
 
 /**
@@ -56,12 +54,8 @@ final class HtmlRenderer
     {
         $children = [];
 
-        if ($node->isName('table')) {
-            return (new TableRenderer)->toElement($node);
-        } elseif ($node->isName('code')) {
-            return (new CodeRenderer)->toElement($node);
-        } elseif ($node->isName('pre')) {
-            return (new PreRenderer)->toElement($node);
+        if (ElementRenderer::hasRenderer($node->getName())) {
+            return ElementRenderer::render($node);
         }
 
         foreach ($node->getChildNodes() as $child) {

--- a/tests/registerRenderer.php
+++ b/tests/registerRenderer.php
@@ -4,6 +4,7 @@ use Termwind\Components\Element;
 use Termwind\Contracts\Renderer;
 use Termwind\Exceptions\InvalidRenderer;
 use Termwind\Html\ElementRenderer;
+use function Termwind\registerRenderer;
 use Termwind\Termwind;
 use Termwind\ValueObjects\Node;
 
@@ -16,7 +17,7 @@ it('adds valid custom renderer', function () {
     expect(ElementRenderer::hasRenderer('custom'))
         ->toBeFalse();
 
-    ElementRenderer::register('custom', CustomRenderer::class);
+    registerRenderer('custom', CustomRenderer::class);
 
     expect(ElementRenderer::hasRenderer('custom'))
         ->toBeTrue();
@@ -25,7 +26,7 @@ it('adds valid custom renderer', function () {
 it('throws exception when adding invalid custom renderer', function () {
     $this->expectException(InvalidRenderer::class);
 
-    ElementRenderer::register('foo', 'bar');
+    registerRenderer('foo', 'bar');
 });
 
 final class CustomRenderer implements Renderer

--- a/tests/renderer.php
+++ b/tests/renderer.php
@@ -2,6 +2,7 @@
 
 use Termwind\Components\Element;
 use Termwind\Contracts\Renderer;
+use Termwind\Exceptions\InvalidRenderer;
 use Termwind\Html\ElementRenderer;
 use Termwind\Termwind;
 use Termwind\ValueObjects\Node;
@@ -11,7 +12,7 @@ it('checks that default renderers are registered', function ($name) {
         ->toBeTrue();
 })->with(['code', 'pre', 'table']);
 
-it('adds custom renderer', function () {
+it('adds valid custom renderer', function () {
     expect(ElementRenderer::hasRenderer('custom'))
         ->toBeFalse();
 
@@ -19,6 +20,12 @@ it('adds custom renderer', function () {
 
     expect(ElementRenderer::hasRenderer('custom'))
         ->toBeTrue();
+});
+
+it('throws exception when adding invalid custom renderer', function () {
+    $this->expectException(InvalidRenderer::class);
+
+    ElementRenderer::register('foo', 'bar');
 });
 
 final class CustomRenderer implements Renderer


### PR DESCRIPTION
I saw that **Termwind** has some default renderers for some elements:
- `TableRenderer`
- `PreRenderer`
- `CodeRenderer`

The purpose of this PR is to allow users to register **Custom Renderers** if they want. This can be a nice addition for developers that want to create plugins, so they can create their own custom renderers.

The general idea is to have a new contract `Renderer` that must be implemented for all renderers and the actual render will be done by the new class `ElementRenderer` that can be used to register new renderers and to use the registered renderers to render the content.

I'm marking this as a **Draft** because I still need to know if this is something that you want to have in the project and if so I can work on modifying anything that's not "compatible" with what you're thinking for the project.

If this is not something you want in the project feel free to decline this, but if you think this can work, I'll be happy to work on any changes needed to have this merged. 😉 💪🏼 🔥 