### PR TITLE
fix: `justify-*` utilities with only one child.

### DIFF
--- a/src/Html/InheritStyles.php
+++ b/src/Html/InheritStyles.php
@@ -89,6 +89,10 @@ final class InheritStyles
      */
     private function applyJustifyBetween(array $elements): array
     {
+        if (count($elements) <= 1) {
+            return $elements;
+        }
+
         [$totalWidth, $parentWidth] = $this->getWidthFromElements($elements);
         $space = ($parentWidth - $totalWidth) / (count($elements) - 1);
 
@@ -146,6 +150,10 @@ final class InheritStyles
      */
     private function applyJustifyAround(array $elements): array
     {
+        if (count($elements) === 0) {
+            return $elements;
+        }
+
         [$totalWidth, $parentWidth] = $this->getWidthFromElements($elements);
         $space = ($parentWidth - $totalWidth) / count($elements);
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -539,6 +539,24 @@ test('justify-between inherit with parent without classes', function () {
     expect($html)->toBe(' A   B   C ');
 });
 
+test('justify-between with only one child', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-2 justify-between">
+            <span>A</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('A ');
+});
+
+test('justify-between with no childs', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-10 justify-between"></div>
+    HTML);
+
+    expect($html)->toBe('          ');
+});
+
 test('justify-evenly', function () {
     $html = parse(<<<'HTML'
         <div class="w-11 justify-evenly">
@@ -587,6 +605,14 @@ test('justify-around with no space available to add', function () {
     expect($html)->toBe('ABC');
 });
 
+test('justify-around with no childs', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-10 justify-around"></div>
+    HTML);
+
+    expect($html)->toBe('          ');
+});
+
 test('justify-center', function () {
     $html = parse(<<<'HTML'
         <div class="w-11 justify-center">
@@ -609,6 +635,16 @@ test('justify-centr with no space available to add', function () {
     HTML);
 
     expect($html)->toBe('ABC');
+});
+
+test('justify-center with only one child', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-11 justify-center">
+            <span>A</span>
+        </div>
+    HTML);
+
+    expect($html)->toBe('     A     ');
 });
 
 test('flex', function () {


### PR DESCRIPTION
This PR fixes a bug found by @dansysanalyst.

When a `justify-between`, `justify-around`, `justify-evenly` was used with only one child.

It gave the following error:

![telegram-cloud-photo-size-4-5985652692598504462-y](https://user-images.githubusercontent.com/823088/217097938-58645920-6fe2-42a9-83ed-f0fc8c9b1c93.jpg)

This PR fixes it.
