### PR TITLE
Add parse function

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ class UsersCommand extends Command
 }
 ```
 
+### `parse()`
+
+The `parse()` function may be used to return the rendered ansi formatted string.
+
+```php
+use function Termwind\{parse};
+
+$string = parse(<<<'HTML'
+  <div class="bg-white underline uppercase">Hello world</div>
+HTML);
+
+// returns "<bg=white>\e[4mHELLO WORLD\e[0m</>"
+```
+
 ### `style()`
 
 The `style()` function may be used to add own custom styles and also update colors.

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -42,6 +42,16 @@ if (! function_exists('Termwind\render')) {
     }
 }
 
+if (! function_exists('Termwind\parse')) {
+    /**
+     * Return HTML as a string.
+     */
+    function parse(string $html): string
+    {
+        return (new HtmlRenderer)->parse($html)->toString();
+    }
+}
+
 if (! function_exists('Termwind\terminal')) {
     /**
      * Returns a Terminal instance.

--- a/tests/parse.php
+++ b/tests/parse.php
@@ -1,0 +1,15 @@
+<?php
+
+it('parses html as a string', function () {
+    $html = \Termwind\parse(<<<'HTML'
+        <div class="bg-white underline uppercase">Hello world</div>
+    HTML);
+
+    expect($html)->toBe("<bg=white>\e[4mHELLO WORLD\e[0m</>");
+});
+
+it('parses a string as a string', function () {
+    $html = \Termwind\parse('text');
+
+    expect($html)->toBe('text');
+});


### PR DESCRIPTION
Adds a new `parse` function that returns the ansi formatted string from some given HTML.

```php
use function Termwind\{parse};

$string = parse(<<<'HTML'
  <div class="bg-white underline uppercase">Hello world</div>
HTML);

// returns "<bg=white>\e[4mHELLO WORLD\e[0m</>"
```