### PR TITLE
[2.x] Adds a `parse` function

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -34,11 +34,21 @@ if (! function_exists('Termwind\style')) {
 
 if (! function_exists('Termwind\render')) {
     /**
-     * Render HTML to a string.
+     * Render HTML to the terminal.
      */
     function render(string $html, int $options = OutputInterface::OUTPUT_NORMAL): void
     {
         (new HtmlRenderer)->render($html, $options);
+    }
+}
+
+if (! function_exists('Termwind\parse')) {
+    /**
+     * Parse HTML to a string that can be rendered in the terminal.
+     */
+    function parse(string $html): string
+    {
+        return (new HtmlRenderer)->parse($html)->toString();
     }
 }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,16 +14,6 @@ uses()->beforeEach(fn () => renderUsing($this->output = new BufferedOutput()))
     })->in(__DIR__);
 
 /**
- * Parses the given html to string.
- */
-function parse(string $html): string
-{
-    $html = (new HtmlRenderer)->parse($html);
-
-    return $html->toString();
-}
-
-/**
  * Gets a input stream resource from a string.
  *
  * @return resource

--- a/tests/a.php
+++ b/tests/a.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse('<a>link text</a>');
 

--- a/tests/br.php
+++ b/tests/br.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse('<br/>');
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -2,6 +2,7 @@
 
 use Termwind\Exceptions\ColorNotFound;
 use Termwind\Exceptions\InvalidStyle;
+use function Termwind\parse;
 
 test('font bold', function () {
     $html = parse('<div class="font-bold">text</div>');

--- a/tests/code.php
+++ b/tests/code.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse(<<<'HTML'
         <div>

--- a/tests/colors.php
+++ b/tests/colors.php
@@ -2,6 +2,7 @@
 
 use Termwind\Exceptions\InvalidColor;
 
+use function Termwind\parse;
 use function Termwind\style;
 
 it('allows the creation of colors', function () {

--- a/tests/div.php
+++ b/tests/div.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse('<div>text</div>');
 

--- a/tests/dl.php
+++ b/tests/dl.php
@@ -1,6 +1,7 @@
 <?php
 
 use Termwind\Exceptions\InvalidChild;
+use function Termwind\parse;
 
 it('accepts multiple elements', function () {
     $dl = parse(<<<'HTML'

--- a/tests/em.php
+++ b/tests/em.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse('<em>text</em>');
 

--- a/tests/hr.php
+++ b/tests/hr.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     putenv('COLUMNS=10');
 

--- a/tests/mediaQueries.php
+++ b/tests/mediaQueries.php
@@ -1,6 +1,7 @@
 <?php
 
 use Termwind\Actions\StyleToMethod;
+use function Termwind\parse;
 
 it('supports styling', function ($name) {
     putenv('COLUMNS='.StyleToMethod::MEDIA_QUERY_BREAKPOINTS[$name]);

--- a/tests/ol.php
+++ b/tests/ol.php
@@ -1,6 +1,7 @@
 <?php
 
 use Termwind\Exceptions\InvalidChild;
+use function Termwind\parse;
 
 it('renders the element', function () {
     $html = parse('<ol><li>list text 1</li></ol>');

--- a/tests/paragraph.php
+++ b/tests/paragraph.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse('<p>text</p>');
 

--- a/tests/pre.php
+++ b/tests/pre.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $content = '    <h1>Introduction</h1>
 

--- a/tests/render.php
+++ b/tests/render.php
@@ -4,6 +4,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function Termwind\render;
 use function Termwind\renderUsing;
+use function Termwind\parse;
 
 it('can render complex html', function () {
     $html = parse(<<<'HTML'

--- a/tests/s.php
+++ b/tests/s.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse('<s>text</s>');
 

--- a/tests/span.php
+++ b/tests/span.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse('<span>text</span>');
 

--- a/tests/strong.php
+++ b/tests/strong.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse('<strong>text</strong>');
 

--- a/tests/style.php
+++ b/tests/style.php
@@ -2,6 +2,7 @@
 
 use Termwind\Exceptions\StyleNotFound;
 
+use function Termwind\parse;
 use function Termwind\style;
 
 it('allows the creation of styles', function () {

--- a/tests/table.php
+++ b/tests/table.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('can render table without thead, tbody, tfoot to a string', function () {
     $html = parse(<<<'HTML'
 <table style="box">

--- a/tests/u.php
+++ b/tests/u.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Termwind\parse;
+
 it('renders the element', function () {
     $html = parse('<u>text</u>');
 

--- a/tests/ul.php
+++ b/tests/ul.php
@@ -1,6 +1,7 @@
 <?php
 
 use Termwind\Exceptions\InvalidChild;
+use function Termwind\parse;
 
 it('renders the element', function () {
     $html = parse('<ul><li>list text 1</li></ul>');


### PR DESCRIPTION
Hey folks 👋

This PR exposes the `parse` function that was previously limited to internal tests. This allows the user to retrieve a terminal acceptable string without rendering to the console. We can then use the `parse` function in tandem with other console output libraries, like Laravel Prompts:

```php
table(
  ['Name', 'Company'],
  [[parse("<span class='text-red-500'>Luke</span>"), 'Laracasts']]
);
```