### PR TITLE
chore: Set `composer config version` to `2.x`

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -23,6 +23,9 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Set Version
+        run: composer config version "2.x-dev"
+
       - name: Install PHP dependencies
         run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,6 +22,9 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Set Version
+        run: composer config version "2.x-dev"
+
       - name: Install Dependencies
         run: composer update --prefer-stable --no-interaction --no-progress
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install Pest
         run: composer require pestphp/pest:^${{ matrix.pest }} --dev --no-update --with-all-dependencies
 
+      - name: Set Version
+        run: composer config version "2.x-dev"
+
       - name: Install PHP dependencies
         run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
 


### PR DESCRIPTION
This PR adds the support for Pest v3.

And also fix CI to make sure it alias the current branch to `2.x-dev`.