### PR TITLE
Add missing ext-dom PHP dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "ext-dom": "*",
         "ext-mbstring": "*",
         "symfony/console": "^6.4.15"
     },


### PR DESCRIPTION
The PHP DOM extension is required to use \DOMDocument in HtmlRenderer.
On minimal installs, `ext-dom` may not be available by default, so it needs to be installed/enabled.