### PR TITLE
ci: only run --prefer-lowest on oldest PHP version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,10 @@ jobs:
     strategy:
       matrix:
         php: ['8.2', '8.3', '8.4', '8.5']
-        dependency-version: [prefer-lowest, prefer-stable]
+        dependency-version: [prefer-stable]
+        include:
+          - php: 8.2
+            dependency-version: prefer-lowest
 
     name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.parallel }}
 


### PR DESCRIPTION
in my point of view the `--prefer-lowest` run should only be run for the lowest supported php version