### PR TITLE
feat: allow symfony 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,6 @@ jobs:
       matrix:
         php: ['8.2', '8.3', '8.4', '8.5']
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          # temp
-          - php: 8.5
-            dependency-version: 'no-suggest'
 
     name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.parallel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,10 @@ jobs:
       matrix:
         php: ['8.2', '8.3', '8.4', '8.5']
         dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          # temp
+          - php: 8.5
+            dependency-version: 'no-suggest'
 
     name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.parallel }}
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.2",
         "ext-mbstring": "*",
-        "symfony/console": "^7.3.6"
+        "symfony/console": "^7.3.6 || ^8.0"
     },
     "require-dev": {
         "illuminate/console": "^11.46.1",
@@ -21,7 +21,7 @@
         "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.1.3",
         "phpstan/phpstan": "^1.12.32",
         "phpstan/phpstan-strict-rules": "^1.6.2",
-        "symfony/var-dumper": "^7.3.5",
+        "symfony/var-dumper": "^7.3.5 || ^8.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0.0"
     },
     "autoload": {
@@ -37,8 +37,8 @@
             "Tests\\": "tests/"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
+    "minimum-stability": "RC",
+    "prefer-stable": false,
     "config": {
         "sort-packages": true,
         "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
             "Tests\\": "tests/"
         }
     },
-    "minimum-stability": "RC",
-    "prefer-stable": false,
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "preferred-install": "dist",


### PR DESCRIPTION
Just a quick view if it works.
changes need to reverted

`composer why-not symfony/console 8`

```
Package "symfony/console" could not be found with constraint "8", results below will most likely be incomplete.
brianium/paratest    v7.14.2  requires symfony/console (^6.4.20 || ^7.3.4) 
illuminate/console   v11.46.1 requires symfony/console (^7.0.3)            
laravel/prompts      v0.3.7   requires symfony/console (^6.2|^7.0)         
nunomaduro/collision v8.8.3   requires symfony/console (^7.3.0)  
```