### PR TITLE
Fix width budget dropping newlines beyond the first run

### DIFF
--- a/src/ValueObjects/Styles.php
+++ b/src/ValueObjects/Styles.php
@@ -855,7 +855,7 @@ final class Styles
 
         // @phpstan-ignore-next-line
         $width *= count($matches[0] ?? []) + 1;
-        $width += mb_strwidth($matches[0][0] ?? '', 'UTF-8');
+        $width += mb_strwidth(implode('', $matches[0]), 'UTF-8');
 
         if ($length <= $width) {
             $space = $width - $length;

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -249,6 +249,30 @@ test('w-auto', function () {
     expect($html)->toBe('text');
 });
 
+test('w-* does not truncate multiline content', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-10">
+            <div>0123456789</div>
+            <div>0123456789</div>
+            <div>0123456789</div>
+        </div>
+    HTML);
+
+    expect($html)->toBe("0123456789\n0123456789\n0123456789");
+});
+
+test('w-* with justify-between keeps every line intact', function () {
+    $html = parse(<<<'HTML'
+        <div class="w-20">
+            <div class="flex justify-between"><span>a</span><span>1</span></div>
+            <div class="flex justify-between"><span>b</span><span>2</span></div>
+            <div class="flex justify-between"><span>c</span><span>3</span></div>
+        </div>
+    HTML);
+
+    expect($html)->toBe("a                  1\nb                  2\nc                  3");
+});
+
 test('invalid w-division', function () {
     expect(fn () => parse('<span class="w-invalid">text</span>'))
         ->toThrow(InvalidStyle::class);


### PR DESCRIPTION
Fixes #207.

## Root cause

`Styles::applyWidth()` builds the width budget for multi-line content like this:

```php
preg_match_all("/\n+/", $content, $matches);

$width *= count($matches[0] ?? []) + 1;
$width += mb_strwidth($matches[0][0] ?? '', 'UTF-8');   // only the FIRST run
```

The budget is multiplied by the number of segments, but only the width of the **first** newline run is added back. Meanwhile `getLength()` measures the content with `mb_strwidth()`, where every `"\n"` counts as 1.

So for content spanning N lines the budget is short by exactly **N - 2**. As soon as `$length > $width`, the `else` branch runs `trimText($content, $width)`, which truncates the tail of the entire block rather than any individual line.

## Why the issue reports it as a `justify-between` bug

`justify-between` is the trigger, not the cause. It pads every line to exactly the container width, which removes the slack that would otherwise absorb the miscount. The same truncation happens with plain full-width lines and no flex at all:

```php
parse('<div class="w-10"><div>0123456789</div><div>0123456789</div><div>0123456789</div></div>');
```

Measured characters lost from the tail, before this change:

| lines | 2 | 3 | 4 | 5 | 8 |
|---|---|---|---|---|---|
| truncated | 0 | 1 | 2 | 3 | 6 |

Exactly `N - 2`, which matches the "amount of truncated characters depends on the total amount of rendered lines" in the report.

## The change

Sum every newline run instead of only the first:

```php
$width += mb_strwidth(implode('', $matches[0]), 'UTF-8');
```

The `?? []` is dropped because PHPStan (correctly) flags offset `0` on `preg_match_all` results as always present; the line above keeps its existing `@phpstan-ignore-next-line`.

## Tests

Two regression tests in `tests/classes.php`, next to the existing `w-*` cases: one minimal (no flex), one reproducing the exact scenario from the issue. Both fail on `2.x` and pass with the fix.

`pint --test` passes, `phpstan analyse` reports no errors, and the suite goes from 192 to 194 passing. The 3 failures in `tests/table.php` are pre-existing on a clean checkout and unrelated.
