### PR TITLE
Update tailwind-colors to v4 palette

### DIFF
--- a/src/Enums/Color.php
+++ b/src/Enums/Color.php
@@ -18,19 +18,19 @@ final class Color
 
     public const SLATE_200 = '#e2e8f0';
 
-    public const SLATE_300 = '#cbd5e1';
+    public const SLATE_300 = '#cad5e2';
 
-    public const SLATE_400 = '#94a3b8';
+    public const SLATE_400 = '#90a1b9';
 
-    public const SLATE_500 = '#64748b';
+    public const SLATE_500 = '#62748e';
 
-    public const SLATE_600 = '#475569';
+    public const SLATE_600 = '#45556c';
 
-    public const SLATE_700 = '#334155';
+    public const SLATE_700 = '#314158';
 
-    public const SLATE_800 = '#1e293b';
+    public const SLATE_800 = '#1d293d';
 
-    public const SLATE_900 = '#0f172a';
+    public const SLATE_900 = '#0f172b';
 
     public const GRAY = 'gray';
 
@@ -40,19 +40,19 @@ final class Color
 
     public const GRAY_200 = '#e5e7eb';
 
-    public const GRAY_300 = '#d1d5db';
+    public const GRAY_300 = '#d1d5dc';
 
-    public const GRAY_400 = '#9ca3af';
+    public const GRAY_400 = '#99a1af';
 
-    public const GRAY_500 = '#6b7280';
+    public const GRAY_500 = '#6a7282';
 
-    public const GRAY_600 = '#4b5563';
+    public const GRAY_600 = '#4a5565';
 
-    public const GRAY_700 = '#374151';
+    public const GRAY_700 = '#364153';
 
-    public const GRAY_800 = '#1f2937';
+    public const GRAY_800 = '#1e2939';
 
-    public const GRAY_900 = '#111827';
+    public const GRAY_900 = '#101828';
 
     public const ZINC_50 = '#fafafa';
 
@@ -62,11 +62,11 @@ final class Color
 
     public const ZINC_300 = '#d4d4d8';
 
-    public const ZINC_400 = '#a1a1aa';
+    public const ZINC_400 = '#9f9fa9';
 
-    public const ZINC_500 = '#71717a';
+    public const ZINC_500 = '#71717b';
 
-    public const ZINC_600 = '#52525b';
+    public const ZINC_600 = '#52525c';
 
     public const ZINC_700 = '#3f3f46';
 
@@ -82,7 +82,7 @@ final class Color
 
     public const NEUTRAL_300 = '#d4d4d4';
 
-    public const NEUTRAL_400 = '#a3a3a3';
+    public const NEUTRAL_400 = '#a1a1a1';
 
     public const NEUTRAL_500 = '#737373';
 
@@ -102,13 +102,13 @@ final class Color
 
     public const STONE_300 = '#d6d3d1';
 
-    public const STONE_400 = '#a8a29e';
+    public const STONE_400 = '#a6a09b';
 
-    public const STONE_500 = '#78716c';
+    public const STONE_500 = '#79716b';
 
-    public const STONE_600 = '#57534e';
+    public const STONE_600 = '#57534d';
 
-    public const STONE_700 = '#44403c';
+    public const STONE_700 = '#44403b';
 
     public const STONE_800 = '#292524';
 
@@ -120,65 +120,65 @@ final class Color
 
     public const RED_50 = '#fef2f2';
 
-    public const RED_100 = '#fee2e2';
+    public const RED_100 = '#ffe2e2';
 
-    public const RED_200 = '#fecaca';
+    public const RED_200 = '#ffc9c9';
 
-    public const RED_300 = '#fca5a5';
+    public const RED_300 = '#ffa2a2';
 
-    public const RED_400 = '#f87171';
+    public const RED_400 = '#ff6467';
 
-    public const RED_500 = '#ef4444';
+    public const RED_500 = '#fb2c36';
 
-    public const RED_600 = '#dc2626';
+    public const RED_600 = '#e7000b';
 
-    public const RED_700 = '#b91c1c';
+    public const RED_700 = '#c10007';
 
-    public const RED_800 = '#991b1b';
+    public const RED_800 = '#9f0712';
 
-    public const RED_900 = '#7f1d1d';
+    public const RED_900 = '#82181a';
 
-    public const ORANGE = '#f97316';
+    public const ORANGE = '#ff6900';
 
     public const ORANGE_50 = '#fff7ed';
 
-    public const ORANGE_100 = '#ffedd5';
+    public const ORANGE_100 = '#ffedd4';
 
-    public const ORANGE_200 = '#fed7aa';
+    public const ORANGE_200 = '#ffd6a7';
 
-    public const ORANGE_300 = '#fdba74';
+    public const ORANGE_300 = '#ffb86a';
 
-    public const ORANGE_400 = '#fb923c';
+    public const ORANGE_400 = '#ff8904';
 
-    public const ORANGE_500 = '#f97316';
+    public const ORANGE_500 = '#ff6900';
 
-    public const ORANGE_600 = '#ea580c';
+    public const ORANGE_600 = '#f54900';
 
-    public const ORANGE_700 = '#c2410c';
+    public const ORANGE_700 = '#ca3500';
 
-    public const ORANGE_800 = '#9a3412';
+    public const ORANGE_800 = '#9f2d00';
 
-    public const ORANGE_900 = '#7c2d12';
+    public const ORANGE_900 = '#7e2a0c';
 
     public const AMBER_50 = '#fffbeb';
 
-    public const AMBER_100 = '#fef3c7';
+    public const AMBER_100 = '#fef3c6';
 
-    public const AMBER_200 = '#fde68a';
+    public const AMBER_200 = '#fee685';
 
-    public const AMBER_300 = '#fcd34d';
+    public const AMBER_300 = '#ffd230';
 
-    public const AMBER_400 = '#fbbf24';
+    public const AMBER_400 = '#ffb900';
 
-    public const AMBER_500 = '#f59e0b';
+    public const AMBER_500 = '#fe9a00';
 
-    public const AMBER_600 = '#d97706';
+    public const AMBER_600 = '#e17100';
 
-    public const AMBER_700 = '#b45309';
+    public const AMBER_700 = '#bb4d00';
 
-    public const AMBER_800 = '#92400e';
+    public const AMBER_800 = '#973c00';
 
-    public const AMBER_900 = '#78350f';
+    public const AMBER_900 = '#7b3306';
 
     public const YELLOW = 'yellow';
 
@@ -186,43 +186,43 @@ final class Color
 
     public const YELLOW_50 = '#fefce8';
 
-    public const YELLOW_100 = '#fef9c3';
+    public const YELLOW_100 = '#fef9c2';
 
-    public const YELLOW_200 = '#fef08a';
+    public const YELLOW_200 = '#fff085';
 
-    public const YELLOW_300 = '#fde047';
+    public const YELLOW_300 = '#ffdf20';
 
-    public const YELLOW_400 = '#facc15';
+    public const YELLOW_400 = '#fdc700';
 
-    public const YELLOW_500 = '#eab308';
+    public const YELLOW_500 = '#f0b100';
 
-    public const YELLOW_600 = '#ca8a04';
+    public const YELLOW_600 = '#d08700';
 
-    public const YELLOW_700 = '#a16207';
+    public const YELLOW_700 = '#a65f00';
 
-    public const YELLOW_800 = '#854d0e';
+    public const YELLOW_800 = '#894b00';
 
-    public const YELLOW_900 = '#713f12';
+    public const YELLOW_900 = '#733e0a';
 
     public const LIME_50 = '#f7fee7';
 
-    public const LIME_100 = '#ecfccb';
+    public const LIME_100 = '#ecfcca';
 
-    public const LIME_200 = '#d9f99d';
+    public const LIME_200 = '#d8f999';
 
-    public const LIME_300 = '#bef264';
+    public const LIME_300 = '#bbf451';
 
-    public const LIME_400 = '#a3e635';
+    public const LIME_400 = '#9ae600';
 
-    public const LIME_500 = '#84cc16';
+    public const LIME_500 = '#7ccf00';
 
-    public const LIME_600 = '#65a30d';
+    public const LIME_600 = '#5ea500';
 
-    public const LIME_700 = '#4d7c0f';
+    public const LIME_700 = '#497d00';
 
-    public const LIME_800 = '#3f6212';
+    public const LIME_800 = '#3c6300';
 
-    public const LIME_900 = '#365314';
+    public const LIME_900 = '#35530e';
 
     public const GREEN = 'green';
 
@@ -232,61 +232,61 @@ final class Color
 
     public const GREEN_100 = '#dcfce7';
 
-    public const GREEN_200 = '#bbf7d0';
+    public const GREEN_200 = '#b9f8cf';
 
-    public const GREEN_300 = '#86efac';
+    public const GREEN_300 = '#7bf1a8';
 
-    public const GREEN_400 = '#4ade80';
+    public const GREEN_400 = '#05df72';
 
-    public const GREEN_500 = '#22c55e';
+    public const GREEN_500 = '#00c950';
 
-    public const GREEN_600 = '#16a34a';
+    public const GREEN_600 = '#00a63e';
 
-    public const GREEN_700 = '#15803d';
+    public const GREEN_700 = '#008236';
 
-    public const GREEN_800 = '#166534';
+    public const GREEN_800 = '#016630';
 
-    public const GREEN_900 = '#14532d';
+    public const GREEN_900 = '#0d542b';
 
     public const EMERALD_50 = '#ecfdf5';
 
-    public const EMERALD_100 = '#d1fae5';
+    public const EMERALD_100 = '#d0fae5';
 
-    public const EMERALD_200 = '#a7f3d0';
+    public const EMERALD_200 = '#a4f4cf';
 
-    public const EMERALD_300 = '#6ee7b7';
+    public const EMERALD_300 = '#5ee9b5';
 
-    public const EMERALD_400 = '#34d399';
+    public const EMERALD_400 = '#00d492';
 
-    public const EMERALD_500 = '#10b981';
+    public const EMERALD_500 = '#00bc7d';
 
-    public const EMERALD_600 = '#059669';
+    public const EMERALD_600 = '#009966';
 
-    public const EMERALD_700 = '#047857';
+    public const EMERALD_700 = '#007a55';
 
-    public const EMERALD_800 = '#065f46';
+    public const EMERALD_800 = '#006045';
 
-    public const EMERALD_900 = '#064e3b';
+    public const EMERALD_900 = '#004f3b';
 
     public const TEAL_50 = '#f0fdfa';
 
-    public const TEAL_100 = '#ccfbf1';
+    public const TEAL_100 = '#cbfbf1';
 
-    public const TEAL_200 = '#99f6e4';
+    public const TEAL_200 = '#96f7e4';
 
-    public const TEAL_300 = '#5eead4';
+    public const TEAL_300 = '#46ecd5';
 
-    public const TEAL_400 = '#2dd4bf';
+    public const TEAL_400 = '#00d5be';
 
-    public const TEAL_500 = '#14b8a6';
+    public const TEAL_500 = '#00bba7';
 
-    public const TEAL_600 = '#0d9488';
+    public const TEAL_600 = '#009689';
 
-    public const TEAL_700 = '#0f766e';
+    public const TEAL_700 = '#00786f';
 
-    public const TEAL_800 = '#115e59';
+    public const TEAL_800 = '#005f5a';
 
-    public const TEAL_900 = '#134e4a';
+    public const TEAL_900 = '#0b4f4a';
 
     public const CYAN = 'cyan';
 
@@ -294,43 +294,43 @@ final class Color
 
     public const CYAN_50 = '#ecfeff';
 
-    public const CYAN_100 = '#cffafe';
+    public const CYAN_100 = '#cefafe';
 
-    public const CYAN_200 = '#a5f3fc';
+    public const CYAN_200 = '#a2f4fd';
 
-    public const CYAN_300 = '#67e8f9';
+    public const CYAN_300 = '#53eafd';
 
-    public const CYAN_400 = '#22d3ee';
+    public const CYAN_400 = '#00d3f2';
 
-    public const CYAN_500 = '#06b6d4';
+    public const CYAN_500 = '#00b8db';
 
-    public const CYAN_600 = '#0891b2';
+    public const CYAN_600 = '#0092b8';
 
-    public const CYAN_700 = '#0e7490';
+    public const CYAN_700 = '#007595';
 
-    public const CYAN_800 = '#155e75';
+    public const CYAN_800 = '#005f78';
 
-    public const CYAN_900 = '#164e63';
+    public const CYAN_900 = '#104e64';
 
     public const SKY_50 = '#f0f9ff';
 
-    public const SKY_100 = '#e0f2fe';
+    public const SKY_100 = '#dff2fe';
 
-    public const SKY_200 = '#bae6fd';
+    public const SKY_200 = '#b8e6fe';
 
-    public const SKY_300 = '#7dd3fc';
+    public const SKY_300 = '#74d4ff';
 
-    public const SKY_400 = '#38bdf8';
+    public const SKY_400 = '#00bcff';
 
-    public const SKY_500 = '#0ea5e9';
+    public const SKY_500 = '#00a6f4';
 
-    public const SKY_600 = '#0284c7';
+    public const SKY_600 = '#0084d1';
 
-    public const SKY_700 = '#0369a1';
+    public const SKY_700 = '#0069a8';
 
-    public const SKY_800 = '#075985';
+    public const SKY_800 = '#00598a';
 
-    public const SKY_900 = '#0c4a6e';
+    public const SKY_900 = '#024a70';
 
     public const BLUE = 'blue';
 
@@ -340,141 +340,141 @@ final class Color
 
     public const BLUE_100 = '#dbeafe';
 
-    public const BLUE_200 = '#bfdbfe';
+    public const BLUE_200 = '#bedbff';
 
-    public const BLUE_300 = '#93c5fd';
+    public const BLUE_300 = '#8ec5ff';
 
-    public const BLUE_400 = '#60a5fa';
+    public const BLUE_400 = '#51a2ff';
 
-    public const BLUE_500 = '#3b82f6';
+    public const BLUE_500 = '#2b7fff';
 
-    public const BLUE_600 = '#2563eb';
+    public const BLUE_600 = '#155dfc';
 
-    public const BLUE_700 = '#1d4ed8';
+    public const BLUE_700 = '#1447e6';
 
-    public const BLUE_800 = '#1e40af';
+    public const BLUE_800 = '#193cb8';
 
-    public const BLUE_900 = '#1e3a8a';
+    public const BLUE_900 = '#1c398e';
 
     public const INDIGO_50 = '#eef2ff';
 
     public const INDIGO_100 = '#e0e7ff';
 
-    public const INDIGO_200 = '#c7d2fe';
+    public const INDIGO_200 = '#c6d2ff';
 
-    public const INDIGO_300 = '#a5b4fc';
+    public const INDIGO_300 = '#a3b3ff';
 
-    public const INDIGO_400 = '#818cf8';
+    public const INDIGO_400 = '#7c86ff';
 
-    public const INDIGO_500 = '#6366f1';
+    public const INDIGO_500 = '#615fff';
 
-    public const INDIGO_600 = '#4f46e5';
+    public const INDIGO_600 = '#4f39f6';
 
-    public const INDIGO_700 = '#4338ca';
+    public const INDIGO_700 = '#432dd7';
 
-    public const INDIGO_800 = '#3730a3';
+    public const INDIGO_800 = '#372aac';
 
-    public const INDIGO_900 = '#312e81';
+    public const INDIGO_900 = '#312c85';
 
     public const VIOLET_50 = '#f5f3ff';
 
     public const VIOLET_100 = '#ede9fe';
 
-    public const VIOLET_200 = '#ddd6fe';
+    public const VIOLET_200 = '#ddd6ff';
 
-    public const VIOLET_300 = '#c4b5fd';
+    public const VIOLET_300 = '#c4b4ff';
 
-    public const VIOLET_400 = '#a78bfa';
+    public const VIOLET_400 = '#a684ff';
 
-    public const VIOLET_500 = '#8b5cf6';
+    public const VIOLET_500 = '#8e51ff';
 
-    public const VIOLET_600 = '#7c3aed';
+    public const VIOLET_600 = '#7f22fe';
 
-    public const VIOLET_700 = '#6d28d9';
+    public const VIOLET_700 = '#7008e7';
 
-    public const VIOLET_800 = '#5b21b6';
+    public const VIOLET_800 = '#5d0ec0';
 
-    public const VIOLET_900 = '#4c1d95';
+    public const VIOLET_900 = '#4d179a';
 
     public const PURPLE_50 = '#faf5ff';
 
     public const PURPLE_100 = '#f3e8ff';
 
-    public const PURPLE_200 = '#e9d5ff';
+    public const PURPLE_200 = '#e9d4ff';
 
-    public const PURPLE_300 = '#d8b4fe';
+    public const PURPLE_300 = '#dab2ff';
 
-    public const PURPLE_400 = '#c084fc';
+    public const PURPLE_400 = '#c27aff';
 
-    public const PURPLE_500 = '#a855f7';
+    public const PURPLE_500 = '#ad46ff';
 
-    public const PURPLE_600 = '#9333ea';
+    public const PURPLE_600 = '#9810fa';
 
-    public const PURPLE_700 = '#7e22ce';
+    public const PURPLE_700 = '#8200db';
 
-    public const PURPLE_800 = '#6b21a8';
+    public const PURPLE_800 = '#6e11b0';
 
-    public const PURPLE_900 = '#581c87';
+    public const PURPLE_900 = '#59168b';
 
     public const FUCHSIA_50 = '#fdf4ff';
 
     public const FUCHSIA_100 = '#fae8ff';
 
-    public const FUCHSIA_200 = '#f5d0fe';
+    public const FUCHSIA_200 = '#f6cfff';
 
-    public const FUCHSIA_300 = '#f0abfc';
+    public const FUCHSIA_300 = '#f4a8ff';
 
-    public const FUCHSIA_400 = '#e879f9';
+    public const FUCHSIA_400 = '#ed6aff';
 
-    public const FUCHSIA_500 = '#d946ef';
+    public const FUCHSIA_500 = '#e12afb';
 
-    public const FUCHSIA_600 = '#c026d3';
+    public const FUCHSIA_600 = '#c800de';
 
-    public const FUCHSIA_700 = '#a21caf';
+    public const FUCHSIA_700 = '#a800b7';
 
-    public const FUCHSIA_800 = '#86198f';
+    public const FUCHSIA_800 = '#8a0194';
 
-    public const FUCHSIA_900 = '#701a75';
+    public const FUCHSIA_900 = '#721378';
 
     public const PINK_50 = '#fdf2f8';
 
     public const PINK_100 = '#fce7f3';
 
-    public const PINK_200 = '#fbcfe8';
+    public const PINK_200 = '#fccee8';
 
-    public const PINK_300 = '#f9a8d4';
+    public const PINK_300 = '#fda5d5';
 
-    public const PINK_400 = '#f472b6';
+    public const PINK_400 = '#fb64b6';
 
-    public const PINK_500 = '#ec4899';
+    public const PINK_500 = '#f6339a';
 
-    public const PINK_600 = '#db2777';
+    public const PINK_600 = '#e60076';
 
-    public const PINK_700 = '#be185d';
+    public const PINK_700 = '#c6005c';
 
-    public const PINK_800 = '#9d174d';
+    public const PINK_800 = '#a3004c';
 
-    public const PINK_900 = '#831843';
+    public const PINK_900 = '#861043';
 
     public const ROSE_50 = '#fff1f2';
 
     public const ROSE_100 = '#ffe4e6';
 
-    public const ROSE_200 = '#fecdd3';
+    public const ROSE_200 = '#ffccd3';
 
-    public const ROSE_300 = '#fda4af';
+    public const ROSE_300 = '#ffa1ad';
 
-    public const ROSE_400 = '#fb7185';
+    public const ROSE_400 = '#ff637e';
 
-    public const ROSE_500 = '#f43f5e';
+    public const ROSE_500 = '#ff2056';
 
-    public const ROSE_600 = '#e11d48';
+    public const ROSE_600 = '#ec003f';
 
-    public const ROSE_700 = '#be123c';
+    public const ROSE_700 = '#c70036';
 
-    public const ROSE_800 = '#9f1239';
+    public const ROSE_800 = '#a50036';
 
-    public const ROSE_900 = '#881337';
+    public const ROSE_900 = '#8b0836';
 
     public const MAGENTA = 'magenta';
 

--- a/tests/classes.php
+++ b/tests/classes.php
@@ -118,7 +118,7 @@ test('bg-bright', function () {
 test('bg-color', function () {
     $html = parse('<div class="bg-red-400">text</div>');
 
-    expect($html)->toBe('<bg=#f87171>text</>');
+    expect($html)->toBe('<bg=#ff6467>text</>');
 });
 
 test('text-color', function () {
@@ -360,13 +360,13 @@ test('line-through', function () {
 test('bg-color-number', function () {
     $html = parse('<div class="bg-green-300">text</div>');
 
-    expect($html)->toBe('<bg=#86efac>text</>');
+    expect($html)->toBe('<bg=#7bf1a8>text</>');
 });
 
 test('text-color-number', function () {
     $html = parse('<div class="text-green-300">text</div>');
 
-    expect($html)->toBe('<fg=#86efac>text</>');
+    expect($html)->toBe('<fg=#7bf1a8>text</>');
 });
 
 test('invalid text-color-number', function () {
@@ -468,7 +468,7 @@ test('width, bg, text-right', function () {
         </div>
     HTML);
 
-    expect($html)->toBe('  <bg=#22c55e>Pass</><fg=#e5e7eb>Some Text</>');
+    expect($html)->toBe('  <bg=#00c950>Pass</><fg=#e5e7eb>Some Text</>');
 });
 
 test('max-w with fraction childs', function () {
@@ -492,7 +492,7 @@ test('w-full, bg, margin, text-color, text-right and font-bold', function () {
         </div>
     HTML);
 
-    expect($html)->toBe('     <bg=#22c55e;fg=gray;options=bold>Pass</>Some Text  ');
+    expect($html)->toBe('     <bg=#00c950;fg=gray;options=bold>Pass</>Some Text  ');
 });
 
 test('append-text', function () {

--- a/tests/render.php
+++ b/tests/render.php
@@ -90,7 +90,7 @@ it('can inherit styles', function () {
     HTML
     );
 
-    expect($html)->toBe("<bg=#fca5a5;fg=white>          <bg=#fca5a5;fg=white>Hello</> <fg=blue;bg=#fca5a5>\e[1mworld\e[0m</>          </>");
+    expect($html)->toBe("<bg=#ffa2a2;fg=white>          <bg=#ffa2a2;fg=white>Hello</> <fg=blue;bg=#ffa2a2>\e[1mworld\e[0m</>          </>");
 });
 
 it('can extend colors', function () {
@@ -101,7 +101,7 @@ it('can extend colors', function () {
     HTML
     );
 
-    expect($html)->toBe("\n   <bg=#86efac;fg=black>  🍃 Termwind now have the capability to <bg=#86efac;fg=black;options=bold>extend</> colors!  </>\n");
+    expect($html)->toBe("\n   <bg=#7bf1a8;fg=black>  🍃 Termwind now have the capability to <bg=#7bf1a8;fg=black;options=bold>extend</> colors!  </>\n");
 });
 
 it('can extend with multiple childs and colors', function () {
@@ -112,7 +112,7 @@ it('can extend with multiple childs and colors', function () {
     HTML
     );
 
-    expect($html)->toBe("\n   <bg=#86efac;fg=black>  Termwind <fg=#ef4444;bg=#86efac><fg=#93c5fd;bg=#86efac>now <fg=#6366f1;bg=#86efac>have</> the</> capability</> to extend colors!  </>\n");
+    expect($html)->toBe("\n   <bg=#7bf1a8;fg=black>  Termwind <fg=#fb2c36;bg=#7bf1a8><fg=#8ec5ff;bg=#7bf1a8>now <fg=#615fff;bg=#7bf1a8>have</> the</> capability</> to extend colors!  </>\n");
 });
 
 it('can inherit styles within multiple levels', function () {
@@ -127,7 +127,7 @@ it('can inherit styles within multiple levels', function () {
     HTML
     );
 
-    expect($html)->toBe("\n  <bg=#b91c1c>       <fg=#93c5fd;bg=#b91c1c><bg=#b91c1c;fg=#93c5fd><bg=#b91c1c;fg=#93c5fd><bg=#b91c1c;fg=#93c5fd;options=bold>Termwind</> is great!</></></>     </>  \n");
+    expect($html)->toBe("\n  <bg=#c10007>       <fg=#8ec5ff;bg=#c10007><bg=#c10007;fg=#8ec5ff><bg=#c10007;fg=#8ec5ff><bg=#c10007;fg=#8ec5ff;options=bold>Termwind</> is great!</></></>     </>  \n");
 });
 
 it('trims the text properly when having bg and text colors', function () {
@@ -138,7 +138,7 @@ it('trims the text properly when having bg and text colors', function () {
         </div>
     HTML);
 
-    expect($html)->toBe('<bg=#22c55e>P<bg=#22c55e;options=bold>a</>ss</><fg=#e5e7eb>A</>');
+    expect($html)->toBe('<bg=#00c950>P<bg=#00c950;options=bold>a</>ss</><fg=#e5e7eb>A</>');
 });
 
 it('trims the text properly when having escape codes', function () {
@@ -229,7 +229,7 @@ it('can inherit font-bold', function () {
         </div>
     HTML);
 
-    expect($html)->toBe("<fg=#ef4444;options=bold><fg=#ef4444;options=bold>A</>\n<fg=#ef4444;options=bold>B</></>");
+    expect($html)->toBe("<fg=#fb2c36;options=bold><fg=#fb2c36;options=bold>A</>\n<fg=#fb2c36;options=bold>B</></>");
 });
 
 it('renders a div and table', function () {
@@ -259,7 +259,7 @@ it('renders an emoji correctly with line-breaks correctly', function () {
         </div>
     HTML);
 
-    expect($html)->toBe("        \n\n<fg=#ef4444> ⚽️ </> A ");
+    expect($html)->toBe("        \n\n<fg=#fb2c36> ⚽️ </> A ");
 });
 
 it('renders CJK characters chains of text-center with spaces correctly', function () {


### PR DESCRIPTION
Update all colors to the new Tailwind v4 palette. The colors are converted from oklch to hex based on the values in [Tailwind's color object](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/tailwindcss/src/compat/colors.ts).

Note: `composer test` currently reports three failures in `tests/table.php`. This PR does not modify table rendering or table tests.