### PR TITLE
chore: adds pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--
+- Fill in the form below correctly. This will help the Termwind team to understand the PR and also work on it.
+-->
+
+### What:
+
+- [ ] Bug Fix
+- [ ] New Feature
+
+### Description:
+
+<!-- describe what your PR is solving -->
+
+### Related:
+
+<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->


### PR DESCRIPTION
`CONTRIBUTING.md` tells contributors to follow the template at `.github/PULL_REQUEST_TEMPLATE.md`, but that file has never existed in the repo, so the link is dead. This adds it, using the same template as pokio and Pest.

Fixes #216
